### PR TITLE
Add travel medicine advisory site

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,22 @@
-# ADHS-Chatbot
+# Reisemedizinische Beratung Website
+
+Dieses Projekt enthält eine kleine Beispielanwendung auf Basis von Flask.
+Ärzte können sich anmelden und schnell eine reisemedizinische Beratung
+zusammenstellen. Zudem stehen Patienteninformationen als PDF zur Verfügung.
+
+## Starten
+
+1. Abhängigkeiten installieren:
+   ```bash
+   pip install Flask
+   ```
+2. Anwendung starten:
+   ```bash
+   python website/app.py
+   ```
+
+Die Anwendung ist anschließend unter `http://localhost:5000` erreichbar.
+
+Es existiert ein Beispielbenutzer:
+- **Benutzername:** `doctor`
+- **Passwort:** `password`

--- a/website/app.py
+++ b/website/app.py
@@ -1,0 +1,73 @@
+from flask import Flask, render_template, request, redirect, url_for, session
+from datetime import datetime
+import os
+
+app = Flask(__name__)
+app.secret_key = 'secret-key-change-this'
+
+USERS = {
+    'doctor': 'password'
+}
+
+COUNTRIES = {
+    'Germany': ['Tetanus', 'Measles', 'Influenza'],
+    'Brazil': ['Yellow Fever', 'Hepatitis A', 'Dengue'],
+    'India': ['Typhoid', 'Hepatitis A', 'Rabies']
+}
+
+@app.route('/')
+def index():
+    return render_template('index.html')
+
+@app.route('/login', methods=['GET', 'POST'])
+def login():
+    error = None
+    if request.method == 'POST':
+        username = request.form['username']
+        password = request.form['password']
+        if USERS.get(username) == password:
+            session['user'] = username
+            return redirect(url_for('dashboard'))
+        else:
+            error = 'Ungültige Anmeldedaten'
+    return render_template('login.html', error=error)
+
+@app.route('/logout')
+def logout():
+    session.pop('user', None)
+    return redirect(url_for('index'))
+
+@app.route('/dashboard', methods=['GET', 'POST'])
+def dashboard():
+    if 'user' not in session:
+        return redirect(url_for('login'))
+    advice = None
+    if request.method == 'POST':
+        country = request.form['country']
+        start_date = request.form['start_date']
+        end_date = request.form['end_date']
+        try:
+            start = datetime.strptime(start_date, '%Y-%m-%d')
+            now = datetime.now()
+            diff = (start - now).days
+        except ValueError:
+            diff = 999
+        vaccines = COUNTRIES.get(country, [])
+        advice = {
+            'country': country,
+            'start_date': start_date,
+            'end_date': end_date,
+            'vaccines': vaccines,
+            'quick': diff < 30
+        }
+    return render_template('dashboard.html', countries=COUNTRIES.keys(), advice=advice)
+
+@app.route('/patient-info')
+def patient_info():
+    if 'user' not in session:
+        return redirect(url_for('login'))
+    pdfs = os.listdir(os.path.join('static', 'pdfs'))
+    return render_template('patient_info.html', pdfs=pdfs)
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/website/static/css/style.css
+++ b/website/static/css/style.css
@@ -1,0 +1,47 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 0;
+    padding: 0;
+    background: #f4f4f4;
+}
+nav {
+    background: #333;
+    color: #fff;
+    padding: 10px;
+}
+nav a {
+    color: #fff;
+    margin-right: 10px;
+    text-decoration: none;
+}
+.hero {
+    text-align: center;
+    padding: 50px;
+    background: #e0e0e0;
+}
+.hero .cta {
+    background: #007BFF;
+    color: #fff;
+    padding: 10px 20px;
+    border-radius: 4px;
+    text-decoration: none;
+}
+.map-placeholder {
+    width: 100%;
+    height: 300px;
+    background: url('https://upload.wikimedia.org/wikipedia/commons/8/80/World_map_-_low_resolution.svg') center/contain no-repeat;
+    margin-top: 20px;
+}
+.advice {
+    background: #fff;
+    padding: 20px;
+    border-radius: 4px;
+    margin-top: 20px;
+}
+.quick {
+    color: red;
+    font-weight: bold;
+}
+.error {
+    color: red;
+}

--- a/website/static/pdfs/Dengue.pdf
+++ b/website/static/pdfs/Dengue.pdf
@@ -1,0 +1,1 @@
+Dengue Informationen

--- a/website/static/pdfs/Gelbfieber.pdf
+++ b/website/static/pdfs/Gelbfieber.pdf
@@ -1,0 +1,1 @@
+Gelbfieber Informationen

--- a/website/static/pdfs/Malaria.pdf
+++ b/website/static/pdfs/Malaria.pdf
@@ -1,0 +1,1 @@
+Malaria Informationen

--- a/website/templates/base.html
+++ b/website/templates/base.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="UTF-8">
+    <title>Reisemedizinische Beratung</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
+</head>
+<body>
+    <header>
+        <nav>
+            <a href="{{ url_for('index') }}">Home</a>
+            {% if session.get('user') %}
+            <a href="{{ url_for('dashboard') }}">Dashboard</a>
+            <a href="{{ url_for('patient_info') }}">Patienteninformationen</a>
+            <a href="{{ url_for('logout') }}">Logout</a>
+            {% else %}
+            <a href="{{ url_for('login') }}">Login</a>
+            {% endif %}
+        </nav>
+    </header>
+    <main>
+        {% block content %}{% endblock %}
+    </main>
+</body>
+</html>

--- a/website/templates/dashboard.html
+++ b/website/templates/dashboard.html
@@ -1,0 +1,30 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Beratung</h2>
+<form method="post">
+    <label for="country">Land:</label>
+    <select name="country" id="country" required>
+        {% for c in countries %}
+        <option value="{{ c }}">{{ c }}</option>
+        {% endfor %}
+    </select>
+    <label for="start_date">Reisebeginn:</label>
+    <input type="date" name="start_date" id="start_date" required>
+    <label for="end_date">Reiseende:</label>
+    <input type="date" name="end_date" id="end_date" required>
+    <button type="submit">Beratung anzeigen</button>
+</form>
+{% if advice %}
+<div class="advice">
+    <h3>Empfohlene Impfungen für {{ advice.country }}</h3>
+    <ul>
+        {% for v in advice.vaccines %}
+        <li>{{ v }}</li>
+        {% endfor %}
+    </ul>
+    {% if advice.quick %}
+    <p class="quick">Zeitraum kurz - Schnellimpfschema empfohlen!</p>
+    {% endif %}
+</div>
+{% endif %}
+{% endblock %}

--- a/website/templates/index.html
+++ b/website/templates/index.html
@@ -1,0 +1,9 @@
+{% extends 'base.html' %}
+{% block content %}
+<section class="hero">
+    <h1>Reisemedizinische Beratung so effizient wie noch nie!</h1>
+    <p>Jetzt beraten!</p>
+    <a class="cta" href="{{ url_for('login') }}">Anmelden</a>
+    <div class="map-placeholder">Weltkarte</div>
+</section>
+{% endblock %}

--- a/website/templates/login.html
+++ b/website/templates/login.html
@@ -1,0 +1,12 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Login</h2>
+<form method="post">
+    <label for="username">Benutzername:</label>
+    <input type="text" name="username" id="username" required>
+    <label for="password">Passwort:</label>
+    <input type="password" name="password" id="password" required>
+    <button type="submit">Einloggen</button>
+    {% if error %}<p class="error">{{ error }}</p>{% endif %}
+</form>
+{% endblock %}

--- a/website/templates/patient_info.html
+++ b/website/templates/patient_info.html
@@ -1,0 +1,9 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Patienteninformationen</h2>
+<ul>
+    {% for p in pdfs %}
+    <li><a href="{{ url_for('static', filename='pdfs/' + p) }}" download>{{ p }}</a></li>
+    {% endfor %}
+</ul>
+{% endblock %}


### PR DESCRIPTION
## Summary
- build simple Flask web app for travel medicine advice
- add login, dashboard and patient info pages
- store static PDFs for Malaria, Dengue and Gelbfieber information
- provide basic CSS styling
- update README with setup instructions

## Testing
- `python -m py_compile website/app.py`
- ❌ `pip install Flask` *(failed: environment lacks internet access)*

------
https://chatgpt.com/codex/tasks/task_e_687241be73d48329ac9d6c8eacff5639