### PR TITLE
Add LaGeSo Befundbericht Generator - Streamlit app with Ollama LLM

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,81 @@
-# ADHS-Chatbot
+# LaGeSo Befundbericht Generator
+
+Lokale Streamlit Web-App zur automatischen Erstellung strukturierter psychiatrischer/psychotherapeutischer Befundberichte nach dem LaGeSo-Standard (CU-Standard) aus unstrukturiertem klinischem Text.
+
+## Features
+
+- **Automatische Textextraktion**: Extrahiert Diagnosen, Befunde, Medikation und Anamnese aus Freitext
+- **AMDP-System**: Alle 20 psychopathologischen Kategorien in korrekter Reihenfolge
+- **Multi-Step LLM-Pipeline**: 4-Schritt-Verarbeitung (Extraktion → AMDP → Anamnese → Beurteilung)
+- **Editierbar**: Jeder Berichtsabschnitt ist nach Generierung bearbeitbar
+- **DOCX-Export**: Professionell formatierter Word-Export im CU-Standard
+- **100% lokal**: Keine Cloud, keine externe API – DSGVO-konform mit Ollama
+- **Qualitätsprüfung**: Automatische Checkliste zur Vollständigkeit
+
+## Voraussetzungen
+
+- Python 3.9+
+- [Ollama](https://ollama.ai) installiert und gestartet
+- Ein LLM-Modell (Standard: `llama3.1:8b`)
+
+## Installation
+
+```bash
+# Ollama installieren (falls noch nicht vorhanden)
+# https://ollama.ai
+
+# Modell herunterladen
+ollama pull llama3.1:8b
+
+# In das Projektverzeichnis wechseln
+cd lageso_agent
+
+# Abhängigkeiten installieren
+pip install -r requirements.txt
+```
+
+## Starten
+
+```bash
+cd lageso_agent
+./start.sh
+```
+
+Oder manuell:
+
+```bash
+cd lageso_agent
+streamlit run app.py
+```
+
+Die App öffnet sich unter `http://localhost:8501`.
+
+## Verwendung
+
+1. **Text einfügen**: Klinischen Freitext (Arztnotizen, Befunde, Arztbriefe) links einfügen
+2. **Metadaten ausfüllen**: Patientendaten, Aktenzeichen, Termine eintragen
+3. **Generieren**: "Bericht generieren" klicken
+4. **Prüfen & Bearbeiten**: Jeden Abschnitt rechts prüfen und bei Bedarf anpassen
+5. **Exportieren**: Als DOCX herunterladen
+
+## Dateistruktur
+
+```
+lageso_agent/
+├── app.py              # Streamlit Hauptanwendung
+├── llm_client.py       # Ollama-Client
+├── extractor.py        # Multi-Step Extraktion
+├── report_builder.py   # Berichts-Zusammenstellung
+├── docx_export.py      # Word-Export
+├── prompts.py          # Prompt-Templates
+├── requirements.txt    # Python-Abhängigkeiten
+└── start.sh            # Startskript
+```
+
+## Konfiguration
+
+Alle Einstellungen sind in der Sidebar der App anpassbar:
+
+- **Ollama-Modell**: Standard `llama3.1:8b`, beliebig konfigurierbar
+- **Ollama-URL**: Standard `http://localhost:11434`
+- **Arzt-Stammdaten**: Name, Fachgebiet, Adresse, Kontakt

--- a/README.md
+++ b/README.md
@@ -1,16 +1,19 @@
 # LaGeSo Befundbericht Generator
 
-Lokale Streamlit Web-App zur automatischen Erstellung strukturierter psychiatrischer/psychotherapeutischer Befundberichte nach dem LaGeSo-Standard (CU-Standard) aus unstrukturiertem klinischem Text.
+Lokale Streamlit Web-App zur automatischen Erstellung strukturierter psychiatrischer/psychotherapeutischer Befundberichte nach dem LaGeSo-Standard (CU-Standard, Dr. med. Carsten Urbanek) aus unstrukturiertem klinischem Text.
 
 ## Features
 
-- **Automatische Textextraktion**: Extrahiert Diagnosen, Befunde, Medikation und Anamnese aus Freitext
-- **AMDP-System**: Alle 20 psychopathologischen Kategorien in korrekter Reihenfolge
-- **Multi-Step LLM-Pipeline**: 4-Schritt-Verarbeitung (Extraktion → AMDP → Anamnese → Beurteilung)
+- **Vollständige 12-Abschnitt-Struktur** nach CU-Standard (Vorstellung, Diagnosen, AMDP, Medikation, Verlauf, Sucht, Behandlungen, Psychosoziale Hilfen, Auswirkungen, Gehfähigkeit, Akteneinsicht, Abschluss)
+- **20 AMDP-Kategorien** in exakter CU-Reihenfolge als Fließtext (Bewusstsein bis Psychopharm. Vorbehandlung)
+- **Multi-Step LLM-Pipeline**: 4-Schritt-Verarbeitung (Extraktion, AMDP, Verlauf/Sucht, Auswirkungen)
+- **ICD-10 Validierung**: Erkennung häufiger Fehler (F33.2 vs F33.3, F45.1 etc.)
+- **Checkbox-Widgets** für strukturierte Felder (Psychosoziale Hilfen, Gehfähigkeit, Akteneinsicht)
 - **Editierbar**: Jeder Berichtsabschnitt ist nach Generierung bearbeitbar
 - **DOCX-Export**: Professionell formatierter Word-Export im CU-Standard
-- **100% lokal**: Keine Cloud, keine externe API – DSGVO-konform mit Ollama
-- **Qualitätsprüfung**: Automatische Checkliste zur Vollständigkeit
+- **Qualitäts-Checkliste**: 9 automatische Prüfungen (AMDP Fließtext, BMI, Sprache, etc.)
+- **100% lokal**: Keine Cloud, keine externe API - DSGVO-konform mit Ollama
+- **Anforderungszeitraum**: 2 Jahre (seit Dezember 2024)
 
 ## Voraussetzungen
 
@@ -53,21 +56,38 @@ Die App öffnet sich unter `http://localhost:8501`.
 ## Verwendung
 
 1. **Text einfügen**: Klinischen Freitext (Arztnotizen, Befunde, Arztbriefe) links einfügen
-2. **Metadaten ausfüllen**: Patientendaten, Aktenzeichen, Termine eintragen
-3. **Generieren**: "Bericht generieren" klicken
-4. **Prüfen & Bearbeiten**: Jeden Abschnitt rechts prüfen und bei Bedarf anpassen
-5. **Exportieren**: Als DOCX herunterladen
+2. **Metadaten ausfüllen**: Patientendaten, Aktenzeichen, Vorstellungstermine eintragen
+3. **Generieren**: "Bericht generieren" klicken - 4-Schritt-Pipeline läuft
+4. **Prüfen & Bearbeiten**: Alle 12 Abschnitte rechts prüfen und bei Bedarf anpassen
+5. **Checkboxen setzen**: Psychosoziale Hilfen, Gehfähigkeit, Akteneinsicht
+6. **Qualitätsprüfung**: Sidebar-Checkliste beachten (AMDP, BMI, Sprache etc.)
+7. **Exportieren**: Als DOCX herunterladen
+
+## Berichtsstruktur (12 Abschnitte)
+
+1. Vorstellung (Termine, Frequenz)
+2. Diagnosen (ICD-10)
+3. Psychopathologischer Befund (AMDP-System, 20 Kategorien als Fließtext)
+4. Aktuelle Medikation (nur Psychopharmaka)
+5. Verlauf der Erkrankung
+6. Bei Suchterkrankung (6-Punkte-Anamnese)
+7. Sonstige Behandlungen (nur psychiatrisch/psychotherapeutisch)
+8. Psychosoziale Hilfen (Betreuung, Pflege, AU, Berentung)
+9. Krankheitsbedingte Auswirkungen (Alltag, Beruf, Sozial)
+10. Einschränkungen der Gehfähigkeit
+11. Akteneinsicht
+12. Abschluss
 
 ## Dateistruktur
 
 ```
 lageso_agent/
-├── app.py              # Streamlit Hauptanwendung
-├── llm_client.py       # Ollama-Client
-├── extractor.py        # Multi-Step Extraktion
-├── report_builder.py   # Berichts-Zusammenstellung
-├── docx_export.py      # Word-Export
-├── prompts.py          # Prompt-Templates
+├── app.py              # Streamlit Hauptanwendung (12-Abschnitt-UI)
+├── llm_client.py       # Ollama-Client (generate, extract_json, test_connection)
+├── extractor.py        # 4-Schritt-LLM-Pipeline
+├── report_builder.py   # 12-Abschnitt-Berichts-Zusammenstellung
+├── docx_export.py      # Word-Export im CU-Standard
+├── prompts.py          # Prompt-Templates und AMDP-Kategorien
 ├── requirements.txt    # Python-Abhängigkeiten
 └── start.sh            # Startskript
 ```

--- a/lageso_agent/app.py
+++ b/lageso_agent/app.py
@@ -1,6 +1,8 @@
 """
 LaGeSo Befundbericht Generator – Streamlit Hauptanwendung.
-Lokale Web-App zur Erstellung strukturierter psychiatrischer Befundberichte.
+Lokale Web-App zur Erstellung strukturierter psychiatrischer Befundberichte
+nach dem CU-Standard (Dr. med. Carsten Urbanek).
+Vollständige 12-Abschnitt-Struktur mit allen Pflichtfeldern.
 """
 
 import streamlit as st
@@ -8,9 +10,17 @@ from datetime import date
 
 from llm_client import OllamaClient
 from extractor import extract_data
-from report_builder import build_vorstellung, build_diagnosen, build_medikation
+from report_builder import (
+    build_diagnosen,
+    build_gehfaehigkeit,
+    build_medikation,
+    build_psychosoziale_hilfen,
+    build_verlauf,
+    build_vorstellung,
+    build_sucht,
+)
 from docx_export import export_docx
-from prompts import AMDP_KATEGORIEN, AMDP_LABELS
+from prompts import AMDP_KATEGORIEN, AMDP_LABELS, AMDP_NORMALBEFUND
 
 # --- Seiteneinstellungen ---
 st.set_page_config(
@@ -24,24 +34,12 @@ st.set_page_config(
 st.markdown(
     """
     <style>
-    .main .block-container {
-        padding-top: 2rem;
-        max-width: 1400px;
-    }
+    .main .block-container { padding-top: 1.5rem; max-width: 1500px; }
     .stTextArea textarea {
         font-family: 'Segoe UI', Arial, sans-serif;
-        font-size: 14px;
-        line-height: 1.5;
+        font-size: 13px; line-height: 1.5;
     }
-    div[data-testid="stSidebar"] {
-        min-width: 320px;
-    }
-    .section-header {
-        font-size: 16px;
-        font-weight: bold;
-        margin-top: 12px;
-        margin-bottom: 4px;
-    }
+    div[data-testid="stSidebar"] { min-width: 320px; }
     </style>
     """,
     unsafe_allow_html=True,
@@ -50,12 +48,11 @@ st.markdown(
 
 # --- Session State initialisieren ---
 def init_session_state():
-    """Initialisiert alle Session-State-Variablen."""
     defaults = {
         # Arzt-Stammdaten
         "arzt_name": "Dr. med. Carsten Urbanek",
         "arzt_fachgebiet": "Facharzt für Psychiatrie und Psychotherapie",
-        "arzt_adresse": "Bergmannstraße 5 | 10961 Berlin",
+        "arzt_adresse": "Bergmannstraße 5, 10961 Berlin",
         "arzt_kontakt": "Tel.: 0 7000 / 4000 1000 | Fax: 0 7000 / 4000 1001",
         # Ollama
         "ollama_url": "http://localhost:11434",
@@ -65,22 +62,49 @@ def init_session_state():
         "patient_text": "",
         "patient_name": "",
         "geburtsdatum": "",
-        "adresse": "",
+        "plz_ort": "",
+        "strasse": "",
         "aktenzeichen": "",
         "erstvorstellung": "",
         "letzte_vorstellung": "",
         "frequenz": "",
-        # Generierte Abschnitte
+        # Generierte Abschnitte (12 Abschnitte)
         "generated": False,
-        "section_vorstellung": "",
-        "section_diagnosen": "",
-        "section_befund": "",
-        "section_medikation": "",
-        "section_anamnese": "",
-        "section_beurteilung": "",
+        "sect_vorstellung": "",
+        "sect_diagnosen": "",
+        "sect_befund": "",
         "befund_datum": "",
-        # Rohdaten (für Qualitätsprüfung)
+        "sect_medikation": "",
+        "sect_verlauf": "",
+        "sect_sucht": "",
+        "sect_behandlungen": "",
+        "sect_psychosoziale": "",
+        "sect_ausw_alltag": "",
+        "sect_ausw_beruf": "",
+        "sect_ausw_sozial": "",
+        "sect_gehfaehigkeit": "",
+        "sect_akteneinsicht": "",
+        # Psychosoziale Hilfen (Checkboxen)
+        "psh_betreuung": False,
+        "psh_betreuung_bereiche": "",
+        "psh_einzelhilfe": False,
+        "psh_betreutes_wohnen": False,
+        "psh_heimunterbringung": False,
+        "psh_pflegegrad": "keiner",
+        "psh_au": False,
+        "psh_au_seit": "",
+        "psh_berentung": False,
+        "psh_berentung_seit": "",
+        # Gehfähigkeit
+        "geh_eingeschraenkt": False,
+        "geh_beschreibung": "",
+        # Akteneinsicht
+        "akteneinsicht_ja": True,
+        "akteneinsicht_begruendung": "",
+        # Rohdaten
         "raw_data": None,
+        "verlauf_data": {},
+        "sucht_data": {},
         # Status
         "generation_step": 0,
         "generation_status": "",
@@ -94,9 +118,7 @@ def init_session_state():
 init_session_state()
 
 
-# --- Hilfsfunktionen ---
 def get_arzt_daten() -> dict:
-    """Gibt die aktuellen Arzt-Stammdaten zurück."""
     return {
         "name": st.session_state.arzt_name,
         "fachgebiet": st.session_state.arzt_fachgebiet,
@@ -106,52 +128,62 @@ def get_arzt_daten() -> dict:
 
 
 def run_quality_checks() -> list[tuple[bool, str]]:
-    """Führt die Qualitätsprüfungen durch.
-
-    Returns:
-        Liste von (bestanden, beschreibung) Tuples
-    """
+    """CU-Standard Qualitätsprüfungen."""
     checks = []
     raw = st.session_state.raw_data
+    befund_text = st.session_state.sect_befund
 
-    # 1. Alle 20 AMDP-Kategorien vorhanden
-    if raw and "befund" in raw:
-        befund = raw["befund"]
-        all_present = all(
-            befund.get(k) and befund[k] != "nicht erhoben"
-            for k in AMDP_KATEGORIEN
-        )
-        # Auch prüfen: sind überhaupt alle Schlüssel da?
-        all_keys = all(k in befund for k in AMDP_KATEGORIEN)
-        checks.append((all_present, "Alle 20 AMDP-Kategorien erhoben"))
-    else:
-        checks.append((False, "Alle 20 AMDP-Kategorien erhoben"))
+    # 1. AMDP als Fließtext (nicht nummeriert)
+    is_fliesstext = befund_text and not any(
+        befund_text.strip().startswith(f"{i}.") for i in range(1, 21)
+    )
+    checks.append((is_fliesstext, "AMDP-Befund als Fließtext (nicht nummeriert)"))
 
-    # 2. Mindestens 1 ICD-10 Diagnose
+    # 2. AMDP beginnt mit "Pat."
+    starts_pat = befund_text.strip().startswith("Pat.") if befund_text else False
+    checks.append((starts_pat, 'AMDP-Befund beginnt mit "Pat."'))
+
+    # 3. BMI im AMDP-Befund erwähnt
+    has_bmi = "BMI" in befund_text if befund_text else False
+    checks.append((has_bmi, "BMI im AMDP-Befund angegeben"))
+
+    # 4. Mindestens 1 ICD-10 Diagnose
     has_diag = bool(raw and raw.get("diagnosen"))
     checks.append((has_diag, "Mindestens 1 ICD-10 Diagnose"))
 
-    # 3. Medikation vorhanden
+    # 5. Medikation vorhanden
     has_med = bool(raw and raw.get("medikation"))
-    checks.append((has_med, "Medikation vorhanden"))
+    checks.append((has_med, "Psychopharmakologische Medikation dokumentiert"))
 
-    # 4. Anamnese vorhanden
-    has_anam = bool(
-        st.session_state.section_anamnese
-        and st.session_state.section_anamnese != "[BITTE ERGÄNZEN]"
+    # 6. Nur Psychopharmaka (keine somatische Medikation)
+    somatisch_keywords = ["levothyroxin", "metformin", "ramipril", "ibuprofen", "pantoprazol"]
+    med_text = st.session_state.sect_medikation.lower()
+    no_somatic = not any(kw in med_text for kw in somatisch_keywords)
+    checks.append((no_somatic, "Keine somatische Medikation"))
+
+    # 7. Verlauf vorhanden
+    has_verlauf = bool(
+        st.session_state.sect_verlauf
+        and st.session_state.sect_verlauf != "[BITTE ERGÄNZEN]"
     )
-    checks.append((has_anam, "Anamnese vorhanden"))
+    checks.append((has_verlauf, "Verlauf der Erkrankung vorhanden"))
 
-    # 5. Beurteilung vorhanden
-    has_beurt = bool(
-        st.session_state.section_beurteilung
-        and st.session_state.section_beurteilung != "[BITTE ERGÄNZEN]"
+    # 8. Auswirkungen vorhanden (mind. Alltag)
+    has_ausw = bool(
+        st.session_state.sect_ausw_alltag
+        and st.session_state.sect_ausw_alltag != "[BITTE ERGÄNZEN]"
     )
-    checks.append((has_beurt, "Beurteilung vorhanden"))
+    checks.append((has_ausw, "Krankheitsbedingte Auswirkungen vorhanden"))
 
-    # 6. Befund beginnt mit "Pat."
-    starts_pat = st.session_state.section_befund.strip().startswith("Pat.")
-    checks.append((starts_pat, 'Befund beginnt mit "Pat."'))
+    # 9. Sprache auf Deutsch (kein Denglisch)
+    denglisch = ["improvement", "musculoskeletal", "treatment", "assessment"]
+    all_text = " ".join([
+        st.session_state.sect_befund,
+        st.session_state.sect_verlauf,
+        st.session_state.sect_ausw_alltag,
+    ]).lower()
+    no_denglisch = not any(w in all_text for w in denglisch)
+    checks.append((no_denglisch, "Keine Denglisch-Begriffe"))
 
     return checks
 
@@ -165,16 +197,12 @@ with st.sidebar:
     # --- Ollama-Verbindung ---
     st.subheader("Ollama-Verbindung")
     st.session_state.ollama_model = st.text_input(
-        "Modell",
-        value=st.session_state.ollama_model,
-        help="Name des Ollama-Modells (z.B. llama3.1:8b, mistral, etc.)",
+        "Modell", value=st.session_state.ollama_model,
+        help="z.B. llama3.1:8b, mistral, gemma2:9b",
     )
     st.session_state.ollama_url = st.text_input(
-        "Ollama URL",
-        value=st.session_state.ollama_url,
-        help="URL des Ollama-Servers",
+        "Ollama URL", value=st.session_state.ollama_url,
     )
-
     if st.button("Verbindung testen", use_container_width=True):
         client = OllamaClient(
             base_url=st.session_state.ollama_url,
@@ -191,30 +219,17 @@ with st.sidebar:
 
     # --- Arzt-Stammdaten ---
     st.subheader("Arzt-Stammdaten")
-    st.session_state.arzt_name = st.text_input(
-        "Name", value=st.session_state.arzt_name
-    )
-    st.session_state.arzt_fachgebiet = st.text_input(
-        "Fachgebiet", value=st.session_state.arzt_fachgebiet
-    )
-    st.session_state.arzt_adresse = st.text_input(
-        "Adresse", value=st.session_state.arzt_adresse
-    )
-    st.session_state.arzt_kontakt = st.text_input(
-        "Kontakt", value=st.session_state.arzt_kontakt
-    )
+    st.session_state.arzt_name = st.text_input("Name", value=st.session_state.arzt_name)
+    st.session_state.arzt_fachgebiet = st.text_input("Fachgebiet", value=st.session_state.arzt_fachgebiet)
+    st.session_state.arzt_adresse = st.text_input("Adresse", value=st.session_state.arzt_adresse)
+    st.session_state.arzt_kontakt = st.text_input("Kontakt", value=st.session_state.arzt_kontakt)
 
     st.divider()
 
     # --- Generierungs-Status ---
     if st.session_state.generation_step > 0:
         st.subheader("Generierungs-Status")
-        steps = [
-            "Extraktion",
-            "AMDP-Befund",
-            "Anamnese",
-            "Beurteilung",
-        ]
+        steps = ["Extraktion", "AMDP-Befund", "Verlauf/Sucht", "Auswirkungen"]
         for i, step_name in enumerate(steps, 1):
             if i < st.session_state.generation_step:
                 st.write(f"\u2705 {step_name}")
@@ -222,15 +237,16 @@ with st.sidebar:
                 st.write(f"\u23f3 {step_name}...")
             else:
                 st.write(f"\u2b1c {step_name}")
-
         st.divider()
 
     # --- Qualitäts-Checkliste ---
     if st.session_state.generated:
         st.subheader("Qualitäts-Checkliste")
         checks = run_quality_checks()
-        for passed, desc in checks:
-            icon = "\u2705" if passed else "\u274c"
+        passed = sum(1 for c, _ in checks if c)
+        st.progress(passed / len(checks), text=f"{passed}/{len(checks)} bestanden")
+        for ok, desc in checks:
+            icon = "\u2705" if ok else "\u274c"
             st.write(f"{icon} {desc}")
 
 
@@ -239,11 +255,11 @@ with st.sidebar:
 # ==========================================================
 st.title("\U0001f9e0 LaGeSo Befundbericht Generator")
 st.caption(
-    "Erstellt strukturierte psychiatrische Befundberichte aus unstrukturiertem "
-    "klinischen Text \u2013 lokal und DSGVO-konform mit Ollama."
+    "Erstellt strukturierte psychiatrische Befundberichte (CU-Standard) aus "
+    "unstrukturiertem klinischen Text \u2013 lokal und DSGVO-konform mit Ollama. "
+    "Anforderungszeitraum: 2 Jahre."
 )
 
-# --- 2-Panel Layout ---
 col_input, col_output = st.columns([1, 1], gap="large")
 
 # ==========================================================
@@ -252,7 +268,6 @@ col_input, col_output = st.columns([1, 1], gap="large")
 with col_input:
     st.header("Eingabe")
 
-    # Freitext
     st.session_state.patient_text = st.text_area(
         "Klinischer Text (Arztnotizen, Befunde, Arztbriefe)",
         value=st.session_state.patient_text,
@@ -261,57 +276,56 @@ with col_input:
             "Fügen Sie hier den unstrukturierten klinischen Text ein...\n\n"
             "Beispiel: Pat. stellt sich erstmals in der Praxis vor. "
             "Bekannte Diagnose einer rezidivierenden depressiven Störung, "
-            "gegenwärtig schwere Episode..."
+            "gegenwärtig schwere Episode. Medikation: Escitalopram 10mg 1-0-0-0..."
         ),
     )
 
-    # Metadaten
+    # --- Patientendaten ---
     st.subheader("Patientendaten")
-    meta_col1, meta_col2 = st.columns(2)
-
-    with meta_col1:
+    mc1, mc2 = st.columns(2)
+    with mc1:
         st.session_state.patient_name = st.text_input(
-            "Patientenname",
-            value=st.session_state.patient_name,
-            placeholder="Nachname, Vorname",
+            "Patientenname", value=st.session_state.patient_name,
+            placeholder="Vorname Nachname",
         )
         st.session_state.geburtsdatum = st.text_input(
-            "Geburtsdatum",
-            value=st.session_state.geburtsdatum,
+            "Geburtsdatum", value=st.session_state.geburtsdatum,
             placeholder="TT.MM.JJJJ",
         )
-        st.session_state.adresse = st.text_input(
-            "Adresse",
-            value=st.session_state.adresse,
-            placeholder="Straße Nr., PLZ Ort",
+        st.session_state.plz_ort = st.text_input(
+            "PLZ und Ort", value=st.session_state.plz_ort,
+            placeholder="10961 Berlin",
+        )
+    with mc2:
+        st.session_state.strasse = st.text_input(
+            "Straße und Hausnummer", value=st.session_state.strasse,
+            placeholder="Musterstraße 1",
+        )
+        st.session_state.aktenzeichen = st.text_input(
+            "Aktenzeichen", value=st.session_state.aktenzeichen,
+            placeholder="z.B. DO5 4121849",
         )
 
-    with meta_col2:
-        st.session_state.aktenzeichen = st.text_input(
-            "Aktenzeichen",
-            value=st.session_state.aktenzeichen,
-            placeholder="Az. ...",
-        )
+    # --- Vorstellungsdaten ---
+    st.subheader("Vorstellung")
+    vc1, vc2 = st.columns(2)
+    with vc1:
         st.session_state.erstvorstellung = st.text_input(
-            "Datum Erstvorstellung",
-            value=st.session_state.erstvorstellung,
+            "Erstvorstellung", value=st.session_state.erstvorstellung,
             placeholder="TT.MM.JJJJ",
         )
         st.session_state.letzte_vorstellung = st.text_input(
-            "Datum letzte Vorstellung",
-            value=st.session_state.letzte_vorstellung,
+            "Letzte Vorstellung", value=st.session_state.letzte_vorstellung,
             placeholder="TT.MM.JJJJ",
         )
-
-    st.session_state.frequenz = st.text_input(
-        "Vorstellungsfrequenz",
-        value=st.session_state.frequenz,
-        placeholder="z.B. 14-tägig, monatlich, vierteljährlich",
-    )
+    with vc2:
+        st.session_state.frequenz = st.text_input(
+            "Vorstellungsfrequenz", value=st.session_state.frequenz,
+            placeholder="z.B. 2-4x/Jahr, monatlich, vierteljährlich",
+        )
 
     # --- Generate Button ---
     st.markdown("---")
-
     generate_clicked = st.button(
         "\U0001f9e0 Bericht generieren",
         type="primary",
@@ -331,13 +345,11 @@ with col_input:
                 model=st.session_state.ollama_model,
             )
 
-            # Verbindung prüfen
             ok, msg = client.test_connection()
             if not ok:
                 st.error(f"Ollama nicht erreichbar: {msg}")
             else:
                 progress_bar = st.progress(0, text="Starte Generierung...")
-                status_text = st.empty()
 
                 def update_progress(step: int, desc: str):
                     st.session_state.generation_step = step
@@ -346,33 +358,84 @@ with col_input:
 
                 try:
                     result = extract_data(
-                        client,
-                        st.session_state.patient_text,
+                        client, st.session_state.patient_text,
                         progress_callback=update_progress,
                     )
 
-                    # Ergebnisse in Session State
+                    # Rohdaten speichern
                     st.session_state.raw_data = result["raw_data"]
+                    st.session_state.verlauf_data = result.get("verlauf", {})
+                    st.session_state.sucht_data = result.get("sucht", {})
 
-                    st.session_state.section_vorstellung = build_vorstellung(
+                    # 1. Vorstellung
+                    st.session_state.sect_vorstellung = build_vorstellung(
                         st.session_state.erstvorstellung,
                         st.session_state.letzte_vorstellung,
                         st.session_state.frequenz,
                     )
-                    st.session_state.section_diagnosen = build_diagnosen(
-                        result["diagnosen"]
-                    )
-                    st.session_state.section_befund = result["befund_text"]
+
+                    # 2. Diagnosen
+                    st.session_state.sect_diagnosen = build_diagnosen(result["diagnosen"])
+
+                    # 3. Befund
+                    st.session_state.sect_befund = result["befund_text"]
                     st.session_state.befund_datum = (
                         st.session_state.letzte_vorstellung
                         or date.today().strftime("%d.%m.%Y")
                     )
-                    st.session_state.section_medikation = build_medikation(
-                        result["medikation"],
-                        datum=st.session_state.letzte_vorstellung,
+
+                    # 4. Medikation
+                    st.session_state.sect_medikation = build_medikation(result["medikation"])
+
+                    # 5. Verlauf
+                    verlauf = result.get("verlauf", {})
+                    st.session_state.sect_verlauf = build_verlauf(
+                        verlauf, result.get("verlauf_text", "")
                     )
-                    st.session_state.section_anamnese = result["anamnese_text"]
-                    st.session_state.section_beurteilung = result["beurteilung_text"]
+
+                    # 6. Sucht
+                    sucht = result.get("sucht", {})
+                    st.session_state.sect_sucht = build_sucht(
+                        sucht, result.get("sucht_text", "")
+                    )
+
+                    # 7. Behandlungen
+                    st.session_state.sect_behandlungen = result.get("behandlungen_text", "")
+
+                    # 8. Psychosoziale Hilfen (Standardwerte, vom Arzt auszufüllen)
+                    st.session_state.sect_psychosoziale = build_psychosoziale_hilfen({
+                        "betreuung": st.session_state.psh_betreuung,
+                        "betreuung_bereiche": st.session_state.psh_betreuung_bereiche,
+                        "einzelhilfe": st.session_state.psh_einzelhilfe,
+                        "betreutes_wohnen": st.session_state.psh_betreutes_wohnen,
+                        "heimunterbringung": st.session_state.psh_heimunterbringung,
+                        "pflegegrad": st.session_state.psh_pflegegrad,
+                        "au_psychisch": st.session_state.psh_au,
+                        "au_seit": st.session_state.psh_au_seit,
+                        "berentung": st.session_state.psh_berentung,
+                        "berentung_seit": st.session_state.psh_berentung_seit,
+                    })
+
+                    # 9. Auswirkungen
+                    st.session_state.sect_ausw_alltag = result.get("auswirkungen_alltag", "[BITTE ERGÄNZEN]")
+                    st.session_state.sect_ausw_beruf = result.get("auswirkungen_beruf", "[BITTE ERGÄNZEN]")
+                    st.session_state.sect_ausw_sozial = result.get("auswirkungen_sozial", "[BITTE ERGÄNZEN]")
+
+                    # 10. Gehfähigkeit
+                    st.session_state.sect_gehfaehigkeit = build_gehfaehigkeit(
+                        st.session_state.geh_eingeschraenkt,
+                        st.session_state.geh_beschreibung,
+                    )
+
+                    # 11. Akteneinsicht
+                    if st.session_state.akteneinsicht_ja:
+                        st.session_state.sect_akteneinsicht = "Ja"
+                    else:
+                        st.session_state.sect_akteneinsicht = (
+                            f"Nein - Begründung: "
+                            f"{st.session_state.akteneinsicht_begruendung or '[FEHLT]'}"
+                        )
+
                     st.session_state.generated = True
                     st.session_state.generation_step = 4
 
@@ -389,9 +452,8 @@ with col_input:
     if st.session_state.error_message:
         st.error(st.session_state.error_message)
 
-
 # ==========================================================
-# RECHTE SEITE: Ergebnis
+# RECHTE SEITE: Ergebnis (12 Abschnitte)
 # ==========================================================
 with col_output:
     st.header("Befundbericht")
@@ -399,107 +461,250 @@ with col_output:
     if not st.session_state.generated:
         st.info(
             "Geben Sie links einen klinischen Text ein und klicken Sie auf "
-            '"\U0001f9e0 Bericht generieren", um den Befundbericht zu erstellen.'
+            '"\U0001f9e0 Bericht generieren".'
         )
+        with st.expander("AMDP-Normalbefund (Vorlage)"):
+            st.text(AMDP_NORMALBEFUND)
     else:
-        # --- Editierbare Abschnitte ---
-
-        # 1. Vorstellung
+        # === 1. VORSTELLUNG ===
         st.markdown("**1. VORSTELLUNG**")
-        st.session_state.section_vorstellung = st.text_area(
-            "Vorstellung",
-            value=st.session_state.section_vorstellung,
-            height=100,
-            label_visibility="collapsed",
-            key="edit_vorstellung",
+        st.session_state.sect_vorstellung = st.text_area(
+            "Vorstellung", value=st.session_state.sect_vorstellung,
+            height=90, label_visibility="collapsed", key="e_vorstellung",
         )
 
-        # 2. Diagnosen
+        # === 2. DIAGNOSEN ===
         st.markdown("**2. DIAGNOSEN (ICD-10)**")
-        st.session_state.section_diagnosen = st.text_area(
-            "Diagnosen",
-            value=st.session_state.section_diagnosen,
-            height=100,
-            label_visibility="collapsed",
-            key="edit_diagnosen",
+        st.caption("Format: ICD-Code (Diagnosetext). F33.2 = ohne Psychose, F33.3 = mit Psychose.")
+        st.session_state.sect_diagnosen = st.text_area(
+            "Diagnosen", value=st.session_state.sect_diagnosen,
+            height=100, label_visibility="collapsed", key="e_diagnosen",
         )
 
-        # 3. Psychopathologischer Befund
+        # === 3. PSYCHOPATHOLOGISCHER BEFUND ===
         st.markdown(
             f"**3. PSYCHOPATHOLOGISCHER BEFUND** "
-            f"_(AMDP-System \u2013 letzter Befund vom "
-            f"{st.session_state.befund_datum})_"
+            f"_(AMDP-System, Datum: {st.session_state.befund_datum})_"
         )
-        st.session_state.section_befund = st.text_area(
-            "Befund",
-            value=st.session_state.section_befund,
-            height=250,
-            label_visibility="collapsed",
-            key="edit_befund",
+        st.caption(
+            "Fließtext, NICHT nummeriert! 20 Kategorien: Bewusstsein \u2192 Stimmung \u2192 "
+            "Affekt \u2192 Konzentration \u2192 Merkfähigkeit \u2192 Interesse \u2192 "
+            "Formales Denken \u2192 Inhaltliches Denken \u2192 Wahrnehmung+Ich-Störungen \u2192 "
+            "Zwänge/Phobien \u2192 Antrieb \u2192 Psychomotorik \u2192 Schlaf \u2192 "
+            "Appetit \u2192 Gewicht \u2192 BMI \u2192 Suizidalität \u2192 "
+            "Eigen-/Fremdgefährdung \u2192 Psychopharm. Vorbehandlung"
+        )
+        st.session_state.sect_befund = st.text_area(
+            "Befund", value=st.session_state.sect_befund,
+            height=250, label_visibility="collapsed", key="e_befund",
         )
 
-        # 4. Medikation
+        # === 4. MEDIKATION ===
         st.markdown("**4. AKTUELLE MEDIKATION** _(nur psychopharmakologisch)_")
-        st.session_state.section_medikation = st.text_area(
-            "Medikation",
-            value=st.session_state.section_medikation,
-            height=120,
-            label_visibility="collapsed",
-            key="edit_medikation",
+        st.caption("Format: DATUM MEDIKAMENT DOSIS SCHEMA (z.B. 13.01.2026 MIRTAZAPIN 15MG 0-0-0-0,5)")
+        st.session_state.sect_medikation = st.text_area(
+            "Medikation", value=st.session_state.sect_medikation,
+            height=120, label_visibility="collapsed", key="e_medikation",
         )
 
-        # 5. Anamnese
-        st.markdown("**5. ANAMNESE UND BEHANDLUNGSVERLAUF**")
-        st.session_state.section_anamnese = st.text_area(
-            "Anamnese",
-            value=st.session_state.section_anamnese,
-            height=200,
-            label_visibility="collapsed",
-            key="edit_anamnese",
+        # === 5. VERLAUF DER ERKRANKUNG ===
+        st.markdown("**5. VERLAUF DER ERKRANKUNG**")
+        st.session_state.sect_verlauf = st.text_area(
+            "Verlauf", value=st.session_state.sect_verlauf,
+            height=180, label_visibility="collapsed", key="e_verlauf",
         )
 
-        # 6. Beurteilung
-        st.markdown("**6. SOZIALMEDIZINISCHE BEURTEILUNG**")
-        st.session_state.section_beurteilung = st.text_area(
-            "Beurteilung",
-            value=st.session_state.section_beurteilung,
-            height=200,
-            label_visibility="collapsed",
-            key="edit_beurteilung",
+        # === 6. BEI SUCHTERKRANKUNG ===
+        st.markdown("**6. BEI SUCHTERKRANKUNG**")
+        st.caption("Bei Sucht: Konsummuster, letzter Konsum, Entzugssymptomatik, stationäre Behandlung, Abstinenzstatus, aktuelle Anbindung.")
+        st.session_state.sect_sucht = st.text_area(
+            "Suchterkrankung", value=st.session_state.sect_sucht,
+            height=120, label_visibility="collapsed", key="e_sucht",
         )
 
-        # --- Export Button ---
+        # === 7. SONSTIGE BEHANDLUNGEN ===
+        st.markdown("**7. SONSTIGE BEHANDLUNGEN** _(wo?, wann?)_")
+        st.caption("NUR psychiatrische/psychotherapeutische Behandlungen. KEINE Physiotherapie.")
+        st.session_state.sect_behandlungen = st.text_area(
+            "Behandlungen", value=st.session_state.sect_behandlungen,
+            height=120, label_visibility="collapsed", key="e_behandlungen",
+        )
+
+        # === 8. PSYCHOSOZIALE HILFEN ===
+        st.markdown("**8. PSYCHOSOZIALE HILFEN**")
+        with st.expander("Psychosoziale Hilfen bearbeiten", expanded=False):
+            pc1, pc2 = st.columns(2)
+            with pc1:
+                st.session_state.psh_betreuung = st.checkbox(
+                    "Gesetzliche Betreuung", value=st.session_state.psh_betreuung,
+                    key="cb_betreuung",
+                )
+                if st.session_state.psh_betreuung:
+                    st.session_state.psh_betreuung_bereiche = st.text_input(
+                        "Für welche Bereiche?", value=st.session_state.psh_betreuung_bereiche,
+                        key="ti_betreuung_bereiche",
+                    )
+                st.session_state.psh_einzelhilfe = st.checkbox(
+                    "Einzelhilfe", value=st.session_state.psh_einzelhilfe, key="cb_einzelhilfe",
+                )
+                st.session_state.psh_betreutes_wohnen = st.checkbox(
+                    "Betreutes Wohnen", value=st.session_state.psh_betreutes_wohnen,
+                    key="cb_betreutes_wohnen",
+                )
+                st.session_state.psh_heimunterbringung = st.checkbox(
+                    "Heimunterbringung", value=st.session_state.psh_heimunterbringung,
+                    key="cb_heimunterbringung",
+                )
+            with pc2:
+                st.session_state.psh_pflegegrad = st.selectbox(
+                    "Pflegegrad",
+                    options=["keiner", "1", "2", "3", "4", "5"],
+                    index=["keiner", "1", "2", "3", "4", "5"].index(
+                        st.session_state.psh_pflegegrad
+                    ),
+                    key="sel_pflegegrad",
+                )
+                st.session_state.psh_au = st.checkbox(
+                    "AU wegen psych. Erkrankung", value=st.session_state.psh_au,
+                    key="cb_au",
+                )
+                if st.session_state.psh_au:
+                    st.session_state.psh_au_seit = st.text_input(
+                        "AU seit:", value=st.session_state.psh_au_seit, key="ti_au_seit",
+                    )
+                st.session_state.psh_berentung = st.checkbox(
+                    "Berentung wegen psych. Erkrankung",
+                    value=st.session_state.psh_berentung, key="cb_berentung",
+                )
+                if st.session_state.psh_berentung:
+                    st.session_state.psh_berentung_seit = st.text_input(
+                        "Berentung seit:", value=st.session_state.psh_berentung_seit,
+                        key="ti_berentung_seit",
+                    )
+
+            # Rebuild text from checkboxes
+            st.session_state.sect_psychosoziale = build_psychosoziale_hilfen({
+                "betreuung": st.session_state.psh_betreuung,
+                "betreuung_bereiche": st.session_state.psh_betreuung_bereiche,
+                "einzelhilfe": st.session_state.psh_einzelhilfe,
+                "betreutes_wohnen": st.session_state.psh_betreutes_wohnen,
+                "heimunterbringung": st.session_state.psh_heimunterbringung,
+                "pflegegrad": st.session_state.psh_pflegegrad,
+                "au_psychisch": st.session_state.psh_au,
+                "au_seit": st.session_state.psh_au_seit,
+                "berentung": st.session_state.psh_berentung,
+                "berentung_seit": st.session_state.psh_berentung_seit,
+            })
+
+        st.text_area(
+            "Psychosoziale Hilfen (Vorschau)",
+            value=st.session_state.sect_psychosoziale,
+            height=100, disabled=True, label_visibility="collapsed",
+            key="e_psychosoziale_preview",
+        )
+
+        # === 9. KRANKHEITSBEDINGTE AUSWIRKUNGEN ===
+        st.markdown("**9. KRANKHEITSBEDINGTE AUSWIRKUNGEN**")
+
+        st.caption("**Alltag:**")
+        st.session_state.sect_ausw_alltag = st.text_area(
+            "Alltag", value=st.session_state.sect_ausw_alltag,
+            height=100, label_visibility="collapsed", key="e_ausw_alltag",
+        )
+        st.caption("**Beruf:**")
+        st.session_state.sect_ausw_beruf = st.text_area(
+            "Beruf", value=st.session_state.sect_ausw_beruf,
+            height=100, label_visibility="collapsed", key="e_ausw_beruf",
+        )
+        st.caption("**Sozial:**")
+        st.session_state.sect_ausw_sozial = st.text_area(
+            "Sozial", value=st.session_state.sect_ausw_sozial,
+            height=100, label_visibility="collapsed", key="e_ausw_sozial",
+        )
+
+        # === 10. EINSCHRÄNKUNGEN DER GEHFÄHIGKEIT ===
+        st.markdown("**10. EINSCHRÄNKUNGEN DER GEHFÄHIGKEIT**")
+        gc1, gc2 = st.columns([1, 3])
+        with gc1:
+            st.session_state.geh_eingeschraenkt = st.checkbox(
+                "Eingeschränkt", value=st.session_state.geh_eingeschraenkt,
+                key="cb_geh",
+            )
+        with gc2:
+            if st.session_state.geh_eingeschraenkt:
+                st.session_state.geh_beschreibung = st.text_input(
+                    "Inwiefern?", value=st.session_state.geh_beschreibung,
+                    key="ti_geh_beschr",
+                )
+        st.session_state.sect_gehfaehigkeit = build_gehfaehigkeit(
+            st.session_state.geh_eingeschraenkt,
+            st.session_state.geh_beschreibung,
+        )
+
+        # === 11. AKTENEINSICHT ===
+        st.markdown("**11. AKTENEINSICHT**")
+        st.session_state.akteneinsicht_ja = st.checkbox(
+            "Kann zur Einsicht gegeben werden", value=st.session_state.akteneinsicht_ja,
+            key="cb_akteneinsicht",
+        )
+        if not st.session_state.akteneinsicht_ja:
+            st.session_state.akteneinsicht_begruendung = st.text_input(
+                "Begründung (pflicht bei Nein):",
+                value=st.session_state.akteneinsicht_begruendung,
+                key="ti_akteneinsicht_begr",
+            )
+        if st.session_state.akteneinsicht_ja:
+            st.session_state.sect_akteneinsicht = "Ja"
+        else:
+            st.session_state.sect_akteneinsicht = (
+                f"Nein - Begründung: "
+                f"{st.session_state.akteneinsicht_begruendung or '[FEHLT]'}"
+            )
+
+        # === 12. ABSCHLUSS === (fester Text)
+        st.markdown("**12. ABSCHLUSS**")
+        st.text(
+            "Den Befundbericht bitte ich gemäß beiliegender Liquidation "
+            "zu entschädigen.\n\nMit freundlichen Grüßen\n\n"
+            f"{st.session_state.arzt_name}"
+        )
+
+        # === EXPORT ===
         st.markdown("---")
+        try:
+            docx_bytes = export_docx(
+                arzt_daten=get_arzt_daten(),
+                patient_name=st.session_state.patient_name,
+                geburtsdatum=st.session_state.geburtsdatum,
+                plz_ort=st.session_state.plz_ort,
+                strasse=st.session_state.strasse,
+                aktenzeichen=st.session_state.aktenzeichen,
+                vorstellung_text=st.session_state.sect_vorstellung,
+                diagnosen_text=st.session_state.sect_diagnosen,
+                befund_text=st.session_state.sect_befund,
+                befund_datum=st.session_state.befund_datum,
+                medikation_text=st.session_state.sect_medikation,
+                verlauf_text=st.session_state.sect_verlauf,
+                sucht_text=st.session_state.sect_sucht,
+                behandlungen_text=st.session_state.sect_behandlungen,
+                psychosoziale_hilfen_text=st.session_state.sect_psychosoziale,
+                auswirkungen_alltag=st.session_state.sect_ausw_alltag,
+                auswirkungen_beruf=st.session_state.sect_ausw_beruf,
+                auswirkungen_sozial=st.session_state.sect_ausw_sozial,
+                gehfaehigkeit_text=st.session_state.sect_gehfaehigkeit,
+                akteneinsicht_text=st.session_state.sect_akteneinsicht,
+            )
 
-        export_col1, export_col2 = st.columns([1, 1])
-        with export_col1:
-            try:
-                docx_bytes = export_docx(
-                    arzt_daten=get_arzt_daten(),
-                    patient_name=st.session_state.patient_name,
-                    geburtsdatum=st.session_state.geburtsdatum,
-                    adresse=st.session_state.adresse,
-                    aktenzeichen=st.session_state.aktenzeichen,
-                    vorstellung_text=st.session_state.section_vorstellung,
-                    diagnosen_text=st.session_state.section_diagnosen,
-                    befund_text=st.session_state.section_befund,
-                    befund_datum=st.session_state.befund_datum,
-                    medikation_text=st.session_state.section_medikation,
-                    anamnese_text=st.session_state.section_anamnese,
-                    beurteilung_text=st.session_state.section_beurteilung,
-                )
+            patient = st.session_state.patient_name.replace(" ", "_") or "Patient"
+            filename = f"LaGeSo_Befundbericht_{patient}_{date.today().strftime('%Y%m%d')}.docx"
 
-                # Dateiname
-                patient = st.session_state.patient_name.replace(" ", "_") or "Patient"
-                filename = f"LaGeSo_Befundbericht_{patient}_{date.today().strftime('%Y%m%d')}.docx"
-
-                st.download_button(
-                    label="\U0001f4e5 Als DOCX exportieren",
-                    data=docx_bytes,
-                    file_name=filename,
-                    mime="application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-                    use_container_width=True,
-                    type="primary",
-                )
-            except Exception as e:
-                st.error(f"Fehler beim Export: {str(e)}")
+            st.download_button(
+                label="\U0001f4e5 Als DOCX exportieren",
+                data=docx_bytes,
+                file_name=filename,
+                mime="application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+                use_container_width=True,
+                type="primary",
+            )
+        except Exception as e:
+            st.error(f"Fehler beim Export: {str(e)}")

--- a/lageso_agent/app.py
+++ b/lageso_agent/app.py
@@ -1,0 +1,505 @@
+"""
+LaGeSo Befundbericht Generator – Streamlit Hauptanwendung.
+Lokale Web-App zur Erstellung strukturierter psychiatrischer Befundberichte.
+"""
+
+import streamlit as st
+from datetime import date
+
+from llm_client import OllamaClient
+from extractor import extract_data
+from report_builder import build_vorstellung, build_diagnosen, build_medikation
+from docx_export import export_docx
+from prompts import AMDP_KATEGORIEN, AMDP_LABELS
+
+# --- Seiteneinstellungen ---
+st.set_page_config(
+    page_title="LaGeSo Befundbericht Generator",
+    page_icon="\U0001f9e0",
+    layout="wide",
+    initial_sidebar_state="expanded",
+)
+
+# --- Custom CSS ---
+st.markdown(
+    """
+    <style>
+    .main .block-container {
+        padding-top: 2rem;
+        max-width: 1400px;
+    }
+    .stTextArea textarea {
+        font-family: 'Segoe UI', Arial, sans-serif;
+        font-size: 14px;
+        line-height: 1.5;
+    }
+    div[data-testid="stSidebar"] {
+        min-width: 320px;
+    }
+    .section-header {
+        font-size: 16px;
+        font-weight: bold;
+        margin-top: 12px;
+        margin-bottom: 4px;
+    }
+    </style>
+    """,
+    unsafe_allow_html=True,
+)
+
+
+# --- Session State initialisieren ---
+def init_session_state():
+    """Initialisiert alle Session-State-Variablen."""
+    defaults = {
+        # Arzt-Stammdaten
+        "arzt_name": "Dr. med. Carsten Urbanek",
+        "arzt_fachgebiet": "Facharzt für Psychiatrie und Psychotherapie",
+        "arzt_adresse": "Bergmannstraße 5 | 10961 Berlin",
+        "arzt_kontakt": "Tel.: 0 7000 / 4000 1000 | Fax: 0 7000 / 4000 1001",
+        # Ollama
+        "ollama_url": "http://localhost:11434",
+        "ollama_model": "llama3.1:8b",
+        "ollama_connected": False,
+        # Eingabe
+        "patient_text": "",
+        "patient_name": "",
+        "geburtsdatum": "",
+        "adresse": "",
+        "aktenzeichen": "",
+        "erstvorstellung": "",
+        "letzte_vorstellung": "",
+        "frequenz": "",
+        # Generierte Abschnitte
+        "generated": False,
+        "section_vorstellung": "",
+        "section_diagnosen": "",
+        "section_befund": "",
+        "section_medikation": "",
+        "section_anamnese": "",
+        "section_beurteilung": "",
+        "befund_datum": "",
+        # Rohdaten (für Qualitätsprüfung)
+        "raw_data": None,
+        # Status
+        "generation_step": 0,
+        "generation_status": "",
+        "error_message": "",
+    }
+    for key, val in defaults.items():
+        if key not in st.session_state:
+            st.session_state[key] = val
+
+
+init_session_state()
+
+
+# --- Hilfsfunktionen ---
+def get_arzt_daten() -> dict:
+    """Gibt die aktuellen Arzt-Stammdaten zurück."""
+    return {
+        "name": st.session_state.arzt_name,
+        "fachgebiet": st.session_state.arzt_fachgebiet,
+        "adresse": st.session_state.arzt_adresse,
+        "kontakt": st.session_state.arzt_kontakt,
+    }
+
+
+def run_quality_checks() -> list[tuple[bool, str]]:
+    """Führt die Qualitätsprüfungen durch.
+
+    Returns:
+        Liste von (bestanden, beschreibung) Tuples
+    """
+    checks = []
+    raw = st.session_state.raw_data
+
+    # 1. Alle 20 AMDP-Kategorien vorhanden
+    if raw and "befund" in raw:
+        befund = raw["befund"]
+        all_present = all(
+            befund.get(k) and befund[k] != "nicht erhoben"
+            for k in AMDP_KATEGORIEN
+        )
+        # Auch prüfen: sind überhaupt alle Schlüssel da?
+        all_keys = all(k in befund for k in AMDP_KATEGORIEN)
+        checks.append((all_present, "Alle 20 AMDP-Kategorien erhoben"))
+    else:
+        checks.append((False, "Alle 20 AMDP-Kategorien erhoben"))
+
+    # 2. Mindestens 1 ICD-10 Diagnose
+    has_diag = bool(raw and raw.get("diagnosen"))
+    checks.append((has_diag, "Mindestens 1 ICD-10 Diagnose"))
+
+    # 3. Medikation vorhanden
+    has_med = bool(raw and raw.get("medikation"))
+    checks.append((has_med, "Medikation vorhanden"))
+
+    # 4. Anamnese vorhanden
+    has_anam = bool(
+        st.session_state.section_anamnese
+        and st.session_state.section_anamnese != "[BITTE ERGÄNZEN]"
+    )
+    checks.append((has_anam, "Anamnese vorhanden"))
+
+    # 5. Beurteilung vorhanden
+    has_beurt = bool(
+        st.session_state.section_beurteilung
+        and st.session_state.section_beurteilung != "[BITTE ERGÄNZEN]"
+    )
+    checks.append((has_beurt, "Beurteilung vorhanden"))
+
+    # 6. Befund beginnt mit "Pat."
+    starts_pat = st.session_state.section_befund.strip().startswith("Pat.")
+    checks.append((starts_pat, 'Befund beginnt mit "Pat."'))
+
+    return checks
+
+
+# ==========================================================
+# SIDEBAR
+# ==========================================================
+with st.sidebar:
+    st.title("\u2699\ufe0f Einstellungen")
+
+    # --- Ollama-Verbindung ---
+    st.subheader("Ollama-Verbindung")
+    st.session_state.ollama_model = st.text_input(
+        "Modell",
+        value=st.session_state.ollama_model,
+        help="Name des Ollama-Modells (z.B. llama3.1:8b, mistral, etc.)",
+    )
+    st.session_state.ollama_url = st.text_input(
+        "Ollama URL",
+        value=st.session_state.ollama_url,
+        help="URL des Ollama-Servers",
+    )
+
+    if st.button("Verbindung testen", use_container_width=True):
+        client = OllamaClient(
+            base_url=st.session_state.ollama_url,
+            model=st.session_state.ollama_model,
+        )
+        ok, msg = client.test_connection()
+        st.session_state.ollama_connected = ok
+        if ok:
+            st.success(msg)
+        else:
+            st.error(msg)
+
+    st.divider()
+
+    # --- Arzt-Stammdaten ---
+    st.subheader("Arzt-Stammdaten")
+    st.session_state.arzt_name = st.text_input(
+        "Name", value=st.session_state.arzt_name
+    )
+    st.session_state.arzt_fachgebiet = st.text_input(
+        "Fachgebiet", value=st.session_state.arzt_fachgebiet
+    )
+    st.session_state.arzt_adresse = st.text_input(
+        "Adresse", value=st.session_state.arzt_adresse
+    )
+    st.session_state.arzt_kontakt = st.text_input(
+        "Kontakt", value=st.session_state.arzt_kontakt
+    )
+
+    st.divider()
+
+    # --- Generierungs-Status ---
+    if st.session_state.generation_step > 0:
+        st.subheader("Generierungs-Status")
+        steps = [
+            "Extraktion",
+            "AMDP-Befund",
+            "Anamnese",
+            "Beurteilung",
+        ]
+        for i, step_name in enumerate(steps, 1):
+            if i < st.session_state.generation_step:
+                st.write(f"\u2705 {step_name}")
+            elif i == st.session_state.generation_step:
+                st.write(f"\u23f3 {step_name}...")
+            else:
+                st.write(f"\u2b1c {step_name}")
+
+        st.divider()
+
+    # --- Qualitäts-Checkliste ---
+    if st.session_state.generated:
+        st.subheader("Qualitäts-Checkliste")
+        checks = run_quality_checks()
+        for passed, desc in checks:
+            icon = "\u2705" if passed else "\u274c"
+            st.write(f"{icon} {desc}")
+
+
+# ==========================================================
+# HAUPTBEREICH
+# ==========================================================
+st.title("\U0001f9e0 LaGeSo Befundbericht Generator")
+st.caption(
+    "Erstellt strukturierte psychiatrische Befundberichte aus unstrukturiertem "
+    "klinischen Text \u2013 lokal und DSGVO-konform mit Ollama."
+)
+
+# --- 2-Panel Layout ---
+col_input, col_output = st.columns([1, 1], gap="large")
+
+# ==========================================================
+# LINKE SEITE: Eingabe
+# ==========================================================
+with col_input:
+    st.header("Eingabe")
+
+    # Freitext
+    st.session_state.patient_text = st.text_area(
+        "Klinischer Text (Arztnotizen, Befunde, Arztbriefe)",
+        value=st.session_state.patient_text,
+        height=300,
+        placeholder=(
+            "Fügen Sie hier den unstrukturierten klinischen Text ein...\n\n"
+            "Beispiel: Pat. stellt sich erstmals in der Praxis vor. "
+            "Bekannte Diagnose einer rezidivierenden depressiven Störung, "
+            "gegenwärtig schwere Episode..."
+        ),
+    )
+
+    # Metadaten
+    st.subheader("Patientendaten")
+    meta_col1, meta_col2 = st.columns(2)
+
+    with meta_col1:
+        st.session_state.patient_name = st.text_input(
+            "Patientenname",
+            value=st.session_state.patient_name,
+            placeholder="Nachname, Vorname",
+        )
+        st.session_state.geburtsdatum = st.text_input(
+            "Geburtsdatum",
+            value=st.session_state.geburtsdatum,
+            placeholder="TT.MM.JJJJ",
+        )
+        st.session_state.adresse = st.text_input(
+            "Adresse",
+            value=st.session_state.adresse,
+            placeholder="Straße Nr., PLZ Ort",
+        )
+
+    with meta_col2:
+        st.session_state.aktenzeichen = st.text_input(
+            "Aktenzeichen",
+            value=st.session_state.aktenzeichen,
+            placeholder="Az. ...",
+        )
+        st.session_state.erstvorstellung = st.text_input(
+            "Datum Erstvorstellung",
+            value=st.session_state.erstvorstellung,
+            placeholder="TT.MM.JJJJ",
+        )
+        st.session_state.letzte_vorstellung = st.text_input(
+            "Datum letzte Vorstellung",
+            value=st.session_state.letzte_vorstellung,
+            placeholder="TT.MM.JJJJ",
+        )
+
+    st.session_state.frequenz = st.text_input(
+        "Vorstellungsfrequenz",
+        value=st.session_state.frequenz,
+        placeholder="z.B. 14-tägig, monatlich, vierteljährlich",
+    )
+
+    # --- Generate Button ---
+    st.markdown("---")
+
+    generate_clicked = st.button(
+        "\U0001f9e0 Bericht generieren",
+        type="primary",
+        use_container_width=True,
+        disabled=not st.session_state.patient_text.strip(),
+    )
+
+    if generate_clicked:
+        if not st.session_state.patient_text.strip():
+            st.error("Bitte geben Sie einen klinischen Text ein.")
+        else:
+            st.session_state.error_message = ""
+            st.session_state.generated = False
+
+            client = OllamaClient(
+                base_url=st.session_state.ollama_url,
+                model=st.session_state.ollama_model,
+            )
+
+            # Verbindung prüfen
+            ok, msg = client.test_connection()
+            if not ok:
+                st.error(f"Ollama nicht erreichbar: {msg}")
+            else:
+                progress_bar = st.progress(0, text="Starte Generierung...")
+                status_text = st.empty()
+
+                def update_progress(step: int, desc: str):
+                    st.session_state.generation_step = step
+                    st.session_state.generation_status = desc
+                    progress_bar.progress(step / 4, text=desc)
+
+                try:
+                    result = extract_data(
+                        client,
+                        st.session_state.patient_text,
+                        progress_callback=update_progress,
+                    )
+
+                    # Ergebnisse in Session State
+                    st.session_state.raw_data = result["raw_data"]
+
+                    st.session_state.section_vorstellung = build_vorstellung(
+                        st.session_state.erstvorstellung,
+                        st.session_state.letzte_vorstellung,
+                        st.session_state.frequenz,
+                    )
+                    st.session_state.section_diagnosen = build_diagnosen(
+                        result["diagnosen"]
+                    )
+                    st.session_state.section_befund = result["befund_text"]
+                    st.session_state.befund_datum = (
+                        st.session_state.letzte_vorstellung
+                        or date.today().strftime("%d.%m.%Y")
+                    )
+                    st.session_state.section_medikation = build_medikation(
+                        result["medikation"],
+                        datum=st.session_state.letzte_vorstellung,
+                    )
+                    st.session_state.section_anamnese = result["anamnese_text"]
+                    st.session_state.section_beurteilung = result["beurteilung_text"]
+                    st.session_state.generated = True
+                    st.session_state.generation_step = 4
+
+                    progress_bar.progress(1.0, text="Bericht erfolgreich generiert!")
+                    st.rerun()
+
+                except ConnectionError as e:
+                    st.error(str(e))
+                except TimeoutError as e:
+                    st.error(str(e))
+                except Exception as e:
+                    st.error(f"Fehler bei der Generierung: {str(e)}")
+
+    if st.session_state.error_message:
+        st.error(st.session_state.error_message)
+
+
+# ==========================================================
+# RECHTE SEITE: Ergebnis
+# ==========================================================
+with col_output:
+    st.header("Befundbericht")
+
+    if not st.session_state.generated:
+        st.info(
+            "Geben Sie links einen klinischen Text ein und klicken Sie auf "
+            '"\U0001f9e0 Bericht generieren", um den Befundbericht zu erstellen.'
+        )
+    else:
+        # --- Editierbare Abschnitte ---
+
+        # 1. Vorstellung
+        st.markdown("**1. VORSTELLUNG**")
+        st.session_state.section_vorstellung = st.text_area(
+            "Vorstellung",
+            value=st.session_state.section_vorstellung,
+            height=100,
+            label_visibility="collapsed",
+            key="edit_vorstellung",
+        )
+
+        # 2. Diagnosen
+        st.markdown("**2. DIAGNOSEN (ICD-10)**")
+        st.session_state.section_diagnosen = st.text_area(
+            "Diagnosen",
+            value=st.session_state.section_diagnosen,
+            height=100,
+            label_visibility="collapsed",
+            key="edit_diagnosen",
+        )
+
+        # 3. Psychopathologischer Befund
+        st.markdown(
+            f"**3. PSYCHOPATHOLOGISCHER BEFUND** "
+            f"_(AMDP-System \u2013 letzter Befund vom "
+            f"{st.session_state.befund_datum})_"
+        )
+        st.session_state.section_befund = st.text_area(
+            "Befund",
+            value=st.session_state.section_befund,
+            height=250,
+            label_visibility="collapsed",
+            key="edit_befund",
+        )
+
+        # 4. Medikation
+        st.markdown("**4. AKTUELLE MEDIKATION** _(nur psychopharmakologisch)_")
+        st.session_state.section_medikation = st.text_area(
+            "Medikation",
+            value=st.session_state.section_medikation,
+            height=120,
+            label_visibility="collapsed",
+            key="edit_medikation",
+        )
+
+        # 5. Anamnese
+        st.markdown("**5. ANAMNESE UND BEHANDLUNGSVERLAUF**")
+        st.session_state.section_anamnese = st.text_area(
+            "Anamnese",
+            value=st.session_state.section_anamnese,
+            height=200,
+            label_visibility="collapsed",
+            key="edit_anamnese",
+        )
+
+        # 6. Beurteilung
+        st.markdown("**6. SOZIALMEDIZINISCHE BEURTEILUNG**")
+        st.session_state.section_beurteilung = st.text_area(
+            "Beurteilung",
+            value=st.session_state.section_beurteilung,
+            height=200,
+            label_visibility="collapsed",
+            key="edit_beurteilung",
+        )
+
+        # --- Export Button ---
+        st.markdown("---")
+
+        export_col1, export_col2 = st.columns([1, 1])
+        with export_col1:
+            try:
+                docx_bytes = export_docx(
+                    arzt_daten=get_arzt_daten(),
+                    patient_name=st.session_state.patient_name,
+                    geburtsdatum=st.session_state.geburtsdatum,
+                    adresse=st.session_state.adresse,
+                    aktenzeichen=st.session_state.aktenzeichen,
+                    vorstellung_text=st.session_state.section_vorstellung,
+                    diagnosen_text=st.session_state.section_diagnosen,
+                    befund_text=st.session_state.section_befund,
+                    befund_datum=st.session_state.befund_datum,
+                    medikation_text=st.session_state.section_medikation,
+                    anamnese_text=st.session_state.section_anamnese,
+                    beurteilung_text=st.session_state.section_beurteilung,
+                )
+
+                # Dateiname
+                patient = st.session_state.patient_name.replace(" ", "_") or "Patient"
+                filename = f"LaGeSo_Befundbericht_{patient}_{date.today().strftime('%Y%m%d')}.docx"
+
+                st.download_button(
+                    label="\U0001f4e5 Als DOCX exportieren",
+                    data=docx_bytes,
+                    file_name=filename,
+                    mime="application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+                    use_container_width=True,
+                    type="primary",
+                )
+            except Exception as e:
+                st.error(f"Fehler beim Export: {str(e)}")

--- a/lageso_agent/docx_export.py
+++ b/lageso_agent/docx_export.py
@@ -1,0 +1,233 @@
+"""
+DOCX-Export im CU-Standard für den LaGeSo-Befundbericht.
+Formatierung: Arial 11pt, Überschriften fett 12pt, Kopfzeile 13pt.
+"""
+
+import io
+from datetime import date
+
+from docx import Document
+from docx.enum.text import WD_ALIGN_PARAGRAPH
+from docx.shared import Cm, Pt, RGBColor
+
+
+def _set_run_font(run, size=11, bold=False, font_name="Arial"):
+    """Setzt Schriftart-Eigenschaften für einen Run."""
+    run.font.name = font_name
+    run.font.size = Pt(size)
+    run.font.bold = bold
+    run.font.color.rgb = RGBColor(0, 0, 0)
+
+
+def _add_paragraph(doc, text, size=11, bold=False, alignment=None, spacing_after=6):
+    """Fügt einen formatierten Absatz hinzu."""
+    para = doc.add_paragraph()
+    if alignment is not None:
+        para.alignment = alignment
+    para.paragraph_format.space_after = Pt(spacing_after)
+    para.paragraph_format.space_before = Pt(0)
+
+    run = para.add_run(text)
+    _set_run_font(run, size=size, bold=bold)
+    return para
+
+
+def _add_fliesstext(doc, text, spacing_after=6):
+    """Fügt einen Fließtext-Absatz mit Zeilenabstand 1.3 hinzu."""
+    para = doc.add_paragraph()
+    para.paragraph_format.space_after = Pt(spacing_after)
+    para.paragraph_format.space_before = Pt(0)
+    para.paragraph_format.line_spacing = 1.3
+
+    run = para.add_run(text)
+    _set_run_font(run, size=11)
+    return para
+
+
+def export_docx(
+    arzt_daten: dict,
+    patient_name: str,
+    geburtsdatum: str,
+    adresse: str,
+    aktenzeichen: str,
+    vorstellung_text: str,
+    diagnosen_text: str,
+    befund_text: str,
+    befund_datum: str,
+    medikation_text: str,
+    anamnese_text: str,
+    beurteilung_text: str,
+) -> bytes:
+    """Exportiert den Bericht als DOCX und gibt die Bytes zurück.
+
+    Returns:
+        DOCX-Datei als bytes
+    """
+    doc = Document()
+
+    # --- Seitenränder ---
+    for section in doc.sections:
+        section.left_margin = Cm(2.5)
+        section.right_margin = Cm(2.5)
+        section.top_margin = Cm(2.0)
+        section.bottom_margin = Cm(2.0)
+
+    # --- Kopfzeile: Arzt-Stammdaten ---
+    _add_paragraph(
+        doc,
+        arzt_daten.get("name", ""),
+        size=13,
+        bold=True,
+        spacing_after=2,
+    )
+    _add_paragraph(
+        doc,
+        arzt_daten.get("fachgebiet", ""),
+        size=10,
+        spacing_after=2,
+    )
+    _add_paragraph(
+        doc,
+        arzt_daten.get("adresse", ""),
+        size=10,
+        spacing_after=2,
+    )
+    _add_paragraph(
+        doc,
+        arzt_daten.get("kontakt", ""),
+        size=10,
+        spacing_after=12,
+    )
+
+    # --- Datum rechtsbündig ---
+    heute = date.today().strftime("%d.%m.%Y")
+    _add_paragraph(
+        doc,
+        f"Berlin, den {heute}",
+        size=11,
+        alignment=WD_ALIGN_PARAGRAPH.RIGHT,
+        spacing_after=12,
+    )
+
+    # --- Titel ---
+    _add_paragraph(
+        doc,
+        "Anlage zur Auskunft über die ärztliche Behandlung (LaGeSo)",
+        size=11,
+        bold=True,
+        alignment=WD_ALIGN_PARAGRAPH.CENTER,
+        spacing_after=2,
+    )
+    _add_paragraph(
+        doc,
+        "Psychiatrischer/psychotherapeutischer Befundbericht",
+        size=11,
+        bold=True,
+        alignment=WD_ALIGN_PARAGRAPH.CENTER,
+        spacing_after=12,
+    )
+
+    # --- Patienten-Kopf ---
+    _add_paragraph(
+        doc,
+        f"Patient/in {patient_name or '[Name]'}, "
+        f"geb. am {geburtsdatum or '[Geburtsdatum]'}, "
+        f"wohnhaft in {adresse or '[Adresse]'}",
+        size=11,
+        spacing_after=2,
+    )
+    _add_paragraph(
+        doc,
+        f"Aktenzeichen: {aktenzeichen or '[Aktenzeichen]'}",
+        size=11,
+        spacing_after=12,
+    )
+
+    # --- 1. Vorstellung ---
+    _add_paragraph(doc, "1. VORSTELLUNG", size=12, bold=True, spacing_after=6)
+    for line in vorstellung_text.strip().split("\n"):
+        line = line.strip()
+        if line:
+            _add_paragraph(doc, f"\u2022 {line}", size=11, spacing_after=2)
+
+    # Abstand
+    _add_paragraph(doc, "", size=6, spacing_after=6)
+
+    # --- 2. Diagnosen ---
+    _add_paragraph(doc, "2. DIAGNOSEN (ICD-10)", size=12, bold=True, spacing_after=6)
+    for line in diagnosen_text.strip().split("\n"):
+        line = line.strip()
+        if line:
+            _add_paragraph(doc, f"\u2022 {line}", size=11, spacing_after=2)
+
+    _add_paragraph(doc, "", size=6, spacing_after=6)
+
+    # --- 3. Psychopathologischer Befund ---
+    _add_paragraph(
+        doc,
+        "3. PSYCHOPATHOLOGISCHER BEFUND",
+        size=12,
+        bold=True,
+        spacing_after=2,
+    )
+    _add_paragraph(
+        doc,
+        f"(AMDP-System \u2013 letzter Befund vom {befund_datum or heute})",
+        size=10,
+        spacing_after=6,
+    )
+    _add_fliesstext(doc, befund_text, spacing_after=12)
+
+    # --- 4. Medikation ---
+    _add_paragraph(
+        doc,
+        "4. AKTUELLE MEDIKATION (nur psychopharmakologisch)",
+        size=12,
+        bold=True,
+        spacing_after=6,
+    )
+    for line in medikation_text.strip().split("\n"):
+        line = line.strip()
+        if line:
+            if line.startswith("("):
+                _add_paragraph(doc, line, size=10, spacing_after=2)
+            else:
+                _add_paragraph(doc, f"\u2022 {line}", size=11, spacing_after=2)
+
+    _add_paragraph(doc, "", size=6, spacing_after=6)
+
+    # --- 5. Anamnese ---
+    _add_paragraph(
+        doc,
+        "5. ANAMNESE UND BEHANDLUNGSVERLAUF",
+        size=12,
+        bold=True,
+        spacing_after=6,
+    )
+    _add_fliesstext(doc, anamnese_text, spacing_after=12)
+
+    # --- 6. Beurteilung ---
+    _add_paragraph(
+        doc,
+        "6. SOZIALMEDIZINISCHE BEURTEILUNG",
+        size=12,
+        bold=True,
+        spacing_after=6,
+    )
+    _add_fliesstext(doc, beurteilung_text, spacing_after=24)
+
+    # --- Unterschrift ---
+    _add_paragraph(doc, "", spacing_after=24)
+    _add_paragraph(doc, "___________________________", size=11, spacing_after=2)
+    _add_paragraph(
+        doc,
+        arzt_daten.get("name", ""),
+        size=11,
+        spacing_after=0,
+    )
+
+    # --- In Bytes konvertieren ---
+    buffer = io.BytesIO()
+    doc.save(buffer)
+    buffer.seek(0)
+    return buffer.getvalue()

--- a/lageso_agent/docx_export.py
+++ b/lageso_agent/docx_export.py
@@ -1,5 +1,6 @@
 """
 DOCX-Export im CU-Standard für den LaGeSo-Befundbericht.
+Vollständige 12-Abschnitt-Struktur.
 Formatierung: Arial 11pt, Überschriften fett 12pt, Kopfzeile 13pt.
 """
 
@@ -26,7 +27,6 @@ def _add_paragraph(doc, text, size=11, bold=False, alignment=None, spacing_after
         para.alignment = alignment
     para.paragraph_format.space_after = Pt(spacing_after)
     para.paragraph_format.space_before = Pt(0)
-
     run = para.add_run(text)
     _set_run_font(run, size=size, bold=bold)
     return para
@@ -38,32 +38,55 @@ def _add_fliesstext(doc, text, spacing_after=6):
     para.paragraph_format.space_after = Pt(spacing_after)
     para.paragraph_format.space_before = Pt(0)
     para.paragraph_format.line_spacing = 1.3
-
     run = para.add_run(text)
     _set_run_font(run, size=11)
     return para
+
+
+def _add_section_header(doc, text, spacing_after=6):
+    """Fügt eine Abschnittsüberschrift hinzu (fett, 12pt)."""
+    return _add_paragraph(doc, text, size=12, bold=True, spacing_after=spacing_after)
+
+
+def _add_lines(doc, text, bullet=False, size=11, spacing_after=2):
+    """Fügt mehrzeiligen Text als einzelne Absätze hinzu."""
+    for line in text.strip().split("\n"):
+        line = line.strip()
+        if not line:
+            continue
+        display = f"\u2022 {line}" if bullet else line
+        _add_paragraph(doc, display, size=size, spacing_after=spacing_after)
 
 
 def export_docx(
     arzt_daten: dict,
     patient_name: str,
     geburtsdatum: str,
-    adresse: str,
+    plz_ort: str,
+    strasse: str,
     aktenzeichen: str,
     vorstellung_text: str,
     diagnosen_text: str,
     befund_text: str,
     befund_datum: str,
     medikation_text: str,
-    anamnese_text: str,
-    beurteilung_text: str,
+    verlauf_text: str,
+    sucht_text: str,
+    behandlungen_text: str,
+    psychosoziale_hilfen_text: str,
+    auswirkungen_alltag: str,
+    auswirkungen_beruf: str,
+    auswirkungen_sozial: str,
+    gehfaehigkeit_text: str,
+    akteneinsicht_text: str,
 ) -> bytes:
-    """Exportiert den Bericht als DOCX und gibt die Bytes zurück.
+    """Exportiert den vollständigen 12-Abschnitt-Bericht als DOCX.
 
     Returns:
         DOCX-Datei als bytes
     """
     doc = Document()
+    heute = date.today().strftime("%d.%m.%Y")
 
     # --- Seitenränder ---
     for section in doc.sections:
@@ -73,158 +96,134 @@ def export_docx(
         section.bottom_margin = Cm(2.0)
 
     # --- Kopfzeile: Arzt-Stammdaten ---
-    _add_paragraph(
-        doc,
-        arzt_daten.get("name", ""),
-        size=13,
-        bold=True,
-        spacing_after=2,
-    )
-    _add_paragraph(
-        doc,
-        arzt_daten.get("fachgebiet", ""),
-        size=10,
-        spacing_after=2,
-    )
-    _add_paragraph(
-        doc,
-        arzt_daten.get("adresse", ""),
-        size=10,
-        spacing_after=2,
-    )
-    _add_paragraph(
-        doc,
-        arzt_daten.get("kontakt", ""),
-        size=10,
-        spacing_after=12,
-    )
+    _add_paragraph(doc, arzt_daten.get("name", ""), size=13, bold=True, spacing_after=2)
+    _add_paragraph(doc, arzt_daten.get("fachgebiet", ""), size=10, spacing_after=2)
+    _add_paragraph(doc, arzt_daten.get("adresse", ""), size=10, spacing_after=2)
+    _add_paragraph(doc, arzt_daten.get("kontakt", ""), size=10, spacing_after=12)
 
     # --- Datum rechtsbündig ---
-    heute = date.today().strftime("%d.%m.%Y")
     _add_paragraph(
-        doc,
-        f"Berlin, den {heute}",
-        size=11,
-        alignment=WD_ALIGN_PARAGRAPH.RIGHT,
-        spacing_after=12,
+        doc, f"Berlin, den {heute}",
+        size=11, alignment=WD_ALIGN_PARAGRAPH.RIGHT, spacing_after=12,
     )
 
     # --- Titel ---
     _add_paragraph(
-        doc,
-        "Anlage zur Auskunft über die ärztliche Behandlung (LaGeSo)",
-        size=11,
-        bold=True,
-        alignment=WD_ALIGN_PARAGRAPH.CENTER,
-        spacing_after=2,
+        doc, "Anlage zur Auskunft über die ärztliche Behandlung (LaGeSo)",
+        size=11, bold=True, alignment=WD_ALIGN_PARAGRAPH.CENTER, spacing_after=2,
     )
     _add_paragraph(
-        doc,
-        "Psychiatrischer/psychotherapeutischer Befundbericht",
-        size=11,
-        bold=True,
-        alignment=WD_ALIGN_PARAGRAPH.CENTER,
-        spacing_after=12,
+        doc, "Psychiatrischer/psychotherapeutischer Befundbericht",
+        size=11, bold=True, alignment=WD_ALIGN_PARAGRAPH.CENTER, spacing_after=12,
     )
 
     # --- Patienten-Kopf ---
+    adresse = f"{plz_ort}, {strasse}" if plz_ort and strasse else (plz_ort or strasse or "[Adresse]")
     _add_paragraph(
         doc,
         f"Patient/in {patient_name or '[Name]'}, "
         f"geb. am {geburtsdatum or '[Geburtsdatum]'}, "
-        f"wohnhaft in {adresse or '[Adresse]'}",
-        size=11,
-        spacing_after=2,
+        f"wohnhaft in {adresse}",
+        size=11, spacing_after=2,
     )
-    _add_paragraph(
-        doc,
-        f"Aktenzeichen: {aktenzeichen or '[Aktenzeichen]'}",
-        size=11,
-        spacing_after=12,
-    )
+    _add_paragraph(doc, f"Aktenzeichen: {aktenzeichen or '[Aktenzeichen]'}", size=11, spacing_after=12)
 
-    # --- 1. Vorstellung ---
-    _add_paragraph(doc, "1. VORSTELLUNG", size=12, bold=True, spacing_after=6)
-    for line in vorstellung_text.strip().split("\n"):
-        line = line.strip()
-        if line:
-            _add_paragraph(doc, f"\u2022 {line}", size=11, spacing_after=2)
+    # === 1. VORSTELLUNG ===
+    _add_section_header(doc, "1. VORSTELLUNG")
+    _add_paragraph(doc, "Die Vorstellung erfolgte:", size=11, spacing_after=2)
+    _add_lines(doc, vorstellung_text)
+    _add_paragraph(doc, "", spacing_after=6)
 
-    # Abstand
-    _add_paragraph(doc, "", size=6, spacing_after=6)
-
-    # --- 2. Diagnosen ---
-    _add_paragraph(doc, "2. DIAGNOSEN (ICD-10)", size=12, bold=True, spacing_after=6)
+    # === 2. DIAGNOSEN ===
+    _add_section_header(doc, "2. DIAGNOSEN (ICD-10)")
     for line in diagnosen_text.strip().split("\n"):
         line = line.strip()
         if line:
             _add_paragraph(doc, f"\u2022 {line}", size=11, spacing_after=2)
+    _add_paragraph(doc, "", spacing_after=6)
 
-    _add_paragraph(doc, "", size=6, spacing_after=6)
-
-    # --- 3. Psychopathologischer Befund ---
+    # === 3. PSYCHOPATHOLOGISCHER BEFUND ===
+    _add_section_header(doc, "3. PSYCHOPATHOLOGISCHER BEFUND", spacing_after=2)
     _add_paragraph(
         doc,
-        "3. PSYCHOPATHOLOGISCHER BEFUND",
-        size=12,
-        bold=True,
-        spacing_after=2,
-    )
-    _add_paragraph(
-        doc,
-        f"(AMDP-System \u2013 letzter Befund vom {befund_datum or heute})",
-        size=10,
-        spacing_after=6,
+        f"Letzter vollständiger psychopathologischer Befund \u2013 "
+        f"nach dem AMDP-System (Datum: {befund_datum or heute})",
+        size=10, spacing_after=6,
     )
     _add_fliesstext(doc, befund_text, spacing_after=12)
 
-    # --- 4. Medikation ---
-    _add_paragraph(
-        doc,
-        "4. AKTUELLE MEDIKATION (nur psychopharmakologisch)",
-        size=12,
-        bold=True,
-        spacing_after=6,
-    )
+    # === 4. AKTUELLE MEDIKATION ===
+    _add_section_header(doc, "4. AKTUELLE MEDIKATION (nur psychopharmakologisch)")
     for line in medikation_text.strip().split("\n"):
         line = line.strip()
-        if line:
-            if line.startswith("("):
-                _add_paragraph(doc, line, size=10, spacing_after=2)
-            else:
-                _add_paragraph(doc, f"\u2022 {line}", size=11, spacing_after=2)
+        if not line:
+            continue
+        if line.startswith("("):
+            _add_paragraph(doc, line, size=10, spacing_after=2)
+        else:
+            _add_paragraph(doc, f"\u2022 {line}", size=11, spacing_after=2)
+    _add_paragraph(doc, "", spacing_after=6)
 
-    _add_paragraph(doc, "", size=6, spacing_after=6)
+    # === 5. VERLAUF DER ERKRANKUNG ===
+    _add_section_header(doc, "5. VERLAUF DER ERKRANKUNG")
+    _add_fliesstext(doc, verlauf_text, spacing_after=12)
 
-    # --- 5. Anamnese ---
+    # === 6. BEI SUCHTERKRANKUNG ===
+    _add_section_header(doc, "6. BEI SUCHTERKRANKUNG")
+    _add_fliesstext(doc, sucht_text, spacing_after=12)
+
+    # === 7. SONSTIGE BEHANDLUNGEN ===
+    _add_section_header(doc, "7. SONSTIGE BEHANDLUNGEN (wo?, wann?)")
+    _add_paragraph(
+        doc, "NUR psychiatrische/psychotherapeutische Behandlungen.",
+        size=10, spacing_after=4,
+    )
+    _add_lines(doc, behandlungen_text)
+    _add_paragraph(doc, "", spacing_after=6)
+
+    # === 8. PSYCHOSOZIALE HILFEN ===
+    _add_section_header(doc, "8. PSYCHOSOZIALE HILFEN")
+    _add_lines(doc, psychosoziale_hilfen_text)
+    _add_paragraph(doc, "", spacing_after=6)
+
+    # === 9. KRANKHEITSBEDINGTE AUSWIRKUNGEN ===
+    _add_section_header(doc, "9. KRANKHEITSBEDINGTE AUSWIRKUNGEN")
+
+    _add_paragraph(doc, "Alltag:", size=11, bold=True, spacing_after=2)
+    _add_fliesstext(doc, auswirkungen_alltag, spacing_after=8)
+
+    _add_paragraph(doc, "Beruf:", size=11, bold=True, spacing_after=2)
+    _add_fliesstext(doc, auswirkungen_beruf, spacing_after=8)
+
+    _add_paragraph(doc, "Sozial:", size=11, bold=True, spacing_after=2)
+    _add_fliesstext(doc, auswirkungen_sozial, spacing_after=12)
+
+    # === 10. EINSCHRÄNKUNGEN DER GEHFÄHIGKEIT ===
+    _add_section_header(doc, "10. EINSCHRÄNKUNGEN DER GEHFÄHIGKEIT")
+    _add_paragraph(doc, gehfaehigkeit_text, size=11, spacing_after=12)
+
+    # === 11. AKTENEINSICHT ===
+    _add_section_header(doc, "11. AKTENEINSICHT")
     _add_paragraph(
         doc,
-        "5. ANAMNESE UND BEHANDLUNGSVERLAUF",
-        size=12,
-        bold=True,
-        spacing_after=6,
+        "Im Falle einer Akteneinsicht kann dieser Befundbericht "
+        "dem/der Antragsteller/in zur Einsicht gegeben werden?",
+        size=11, spacing_after=4,
     )
-    _add_fliesstext(doc, anamnese_text, spacing_after=12)
+    _add_paragraph(doc, akteneinsicht_text, size=11, spacing_after=12)
 
-    # --- 6. Beurteilung ---
+    # === 12. ABSCHLUSS ===
+    _add_section_header(doc, "12. ABSCHLUSS")
     _add_paragraph(
         doc,
-        "6. SOZIALMEDIZINISCHE BEURTEILUNG",
-        size=12,
-        bold=True,
-        spacing_after=6,
+        "Den Befundbericht bitte ich gemäß beiliegender Liquidation zu entschädigen.",
+        size=11, spacing_after=8,
     )
-    _add_fliesstext(doc, beurteilung_text, spacing_after=24)
+    _add_paragraph(doc, "Mit freundlichen Grüßen", size=11, spacing_after=24)
 
     # --- Unterschrift ---
-    _add_paragraph(doc, "", spacing_after=24)
     _add_paragraph(doc, "___________________________", size=11, spacing_after=2)
-    _add_paragraph(
-        doc,
-        arzt_daten.get("name", ""),
-        size=11,
-        spacing_after=0,
-    )
+    _add_paragraph(doc, arzt_daten.get("name", ""), size=11, spacing_after=0)
 
     # --- In Bytes konvertieren ---
     buffer = io.BytesIO()

--- a/lageso_agent/extractor.py
+++ b/lageso_agent/extractor.py
@@ -1,6 +1,10 @@
 """
 Multi-Step Extraktion: Rohtext → strukturierte Daten → Fließtexte.
 Orchestriert die 4-Schritt-LLM-Pipeline nach CU-Standard.
+
+DIRECT MODE: Der originale Patiententext wird bei JEDEM Schritt an das LLM
+gesendet. Die JSON-Extraktion aus Schritt 1 dient nur als strukturelle
+Orientierung – das LLM hat immer Zugriff auf den vollständigen Originaltext.
 """
 
 import json
@@ -67,25 +71,26 @@ def extract_data(
     _progress(1, "Extrahiere Informationen aus dem Text...")
     raw_data = _step1_extract(client, patient_text)
 
-    # --- Schritt 2: AMDP-Fließtext ---
+    # --- Schritt 2: AMDP-Fließtext (mit Originaltext!) ---
     _progress(2, "Erstelle psychopathologischen Befund (AMDP)...")
-    befund_text = _step2_amdp(client, raw_data.get("befund", EMPTY_BEFUND))
+    befund_text = _step2_amdp(client, patient_text, raw_data.get("befund", EMPTY_BEFUND))
 
-    # --- Schritt 3: Verlauf + Suchtanamnese ---
+    # --- Schritt 3: Verlauf + Suchtanamnese (mit Originaltext!) ---
     _progress(3, "Erstelle Verlauf und Behandlungshistorie...")
     verlauf_text, sucht_text = _step3_verlauf(
         client,
+        patient_text,
         raw_data.get("anamnese_stichpunkte", []),
         raw_data.get("sucht", {}),
         raw_data.get("verlauf", {}),
     )
 
-    # --- Schritt 4: Krankheitsbedingte Auswirkungen ---
+    # --- Schritt 4: Krankheitsbedingte Auswirkungen (mit Originaltext!) ---
     _progress(4, "Erstelle krankheitsbedingte Auswirkungen...")
     alltag, beruf, sozial = _step4_auswirkungen(
         client,
+        patient_text,
         raw_data.get("diagnosen", []),
-        befund_text,
         raw_data.get("auswirkungen_stichpunkte", {}),
     )
 
@@ -142,10 +147,14 @@ def _step1_extract(client: OllamaClient, patient_text: str) -> dict:
     return data
 
 
-def _step2_amdp(client: OllamaClient, befund: dict) -> str:
-    """Schritt 2: Generiert AMDP-Fließtext aus den Befunddaten."""
+def _step2_amdp(client: OllamaClient, patient_text: str, befund: dict) -> str:
+    """Schritt 2: Generiert AMDP-Fließtext.
+
+    DIRECT MODE: Das LLM bekommt den ORIGINALEN Patiententext plus die
+    vorextrahierten Befund-Stichpunkte als Orientierung.
+    """
     befund_json = json.dumps(befund, ensure_ascii=False, indent=2)
-    prompt = AMDP_PROMPT.format(befund_json=befund_json)
+    prompt = AMDP_PROMPT.format(patient_text=patient_text, befund_json=befund_json)
 
     text = client.generate(prompt)
 
@@ -162,11 +171,15 @@ def _step2_amdp(client: OllamaClient, befund: dict) -> str:
 
 def _step3_verlauf(
     client: OllamaClient,
+    patient_text: str,
     anamnese_stichpunkte: list,
     sucht: dict,
     verlauf: dict,
 ) -> tuple[str, str]:
     """Schritt 3: Generiert Verlauf- und Suchtanamnese-Text.
+
+    DIRECT MODE: Das LLM bekommt den ORIGINALEN Patiententext plus die
+    vorextrahierten Stichpunkte als Orientierung.
 
     Returns:
         Tuple (verlauf_text, sucht_text)
@@ -181,6 +194,7 @@ def _step3_verlauf(
     verlauf_daten = json.dumps(verlauf, ensure_ascii=False, indent=2)
 
     prompt = VERLAUF_PROMPT.format(
+        patient_text=patient_text,
         anamnese_stichpunkte=stichpunkte,
         sucht_daten=sucht_daten,
         verlauf_daten=verlauf_daten,
@@ -204,11 +218,14 @@ def _step3_verlauf(
 
 def _step4_auswirkungen(
     client: OllamaClient,
+    patient_text: str,
     diagnosen: list,
-    befund_text: str,
     auswirkungen_stichpunkte: dict,
 ) -> tuple[str, str, str]:
     """Schritt 4: Generiert die drei Auswirkungs-Texte.
+
+    DIRECT MODE: Das LLM bekommt den ORIGINALEN Patiententext plus die
+    vorextrahierten Stichpunkte als Orientierung.
 
     Returns:
         Tuple (alltag, beruf, sozial)
@@ -224,8 +241,8 @@ def _step4_auswirkungen(
     sozial_sp = auswirkungen_stichpunkte.get("sozial", [])
 
     prompt = AUSWIRKUNGEN_PROMPT.format(
+        patient_text=patient_text,
         diagnosen=diagnosen_text,
-        befund_zusammenfassung=befund_text[:500] if befund_text else "Kein Befund.",
         alltag_stichpunkte=", ".join(alltag_sp) if alltag_sp else "nicht erhoben",
         beruf_stichpunkte=", ".join(beruf_sp) if beruf_sp else "nicht erhoben",
         sozial_stichpunkte=", ".join(sozial_sp) if sozial_sp else "nicht erhoben",

--- a/lageso_agent/extractor.py
+++ b/lageso_agent/extractor.py
@@ -1,6 +1,6 @@
 """
 Multi-Step Extraktion: Rohtext → strukturierte Daten → Fließtexte.
-Orchestriert die 4-Schritt-LLM-Pipeline.
+Orchestriert die 4-Schritt-LLM-Pipeline nach CU-Standard.
 """
 
 import json
@@ -10,11 +10,10 @@ from llm_client import OllamaClient
 from prompts import (
     AMDP_KATEGORIEN,
     AMDP_PROMPT,
-    ANAMNESE_PROMPT,
-    BEURTEILUNG_PROMPT,
+    AUSWIRKUNGEN_PROMPT,
     EXTRACTION_PROMPT,
+    VERLAUF_PROMPT,
 )
-
 
 # Leeres Befund-Template (Fallback)
 EMPTY_BEFUND = {k: "nicht erhoben" for k in AMDP_KATEGORIEN}
@@ -23,8 +22,24 @@ EMPTY_EXTRACTION = {
     "diagnosen": [],
     "befund": dict(EMPTY_BEFUND),
     "medikation": [],
+    "verlauf": {
+        "form": "nicht erhoben",
+        "tendenz": "nicht erhoben",
+        "behandlungserfolg": "nicht erhoben",
+    },
+    "sucht": {"vorhanden": False},
+    "behandlungen": {
+        "stationaer": [],
+        "teilstationaer": [],
+        "ambulant": [],
+        "reha": [],
+    },
+    "auswirkungen_stichpunkte": {
+        "alltag": [],
+        "beruf": [],
+        "sozial": [],
+    },
     "anamnese_stichpunkte": [],
-    "beurteilung_stichpunkte": [],
 }
 
 
@@ -41,14 +56,7 @@ def extract_data(
         progress_callback: Optional callback(step_number, step_description)
 
     Returns:
-        Dict mit Schlüsseln:
-        - raw_data: Extrahierte Rohdaten (JSON)
-        - vorstellung: Vorstellungsdaten (aus Metadaten)
-        - diagnosen: Liste der Diagnosen
-        - befund_text: AMDP-Fließtext
-        - medikation: Medikationsliste
-        - anamnese_text: Anamnese-Fließtext
-        - beurteilung_text: Beurteilungs-Fließtext
+        Dict mit allen extrahierten und generierten Abschnitten.
     """
 
     def _progress(step: int, desc: str):
@@ -63,26 +71,40 @@ def extract_data(
     _progress(2, "Erstelle psychopathologischen Befund (AMDP)...")
     befund_text = _step2_amdp(client, raw_data.get("befund", EMPTY_BEFUND))
 
-    # --- Schritt 3: Anamnese-Fließtext ---
-    _progress(3, "Erstelle Anamnese und Behandlungsverlauf...")
-    anamnese_text = _step3_anamnese(client, raw_data.get("anamnese_stichpunkte", []))
+    # --- Schritt 3: Verlauf + Suchtanamnese ---
+    _progress(3, "Erstelle Verlauf und Behandlungshistorie...")
+    verlauf_text, sucht_text = _step3_verlauf(
+        client,
+        raw_data.get("anamnese_stichpunkte", []),
+        raw_data.get("sucht", {}),
+        raw_data.get("verlauf", {}),
+    )
 
-    # --- Schritt 4: Beurteilung ---
-    _progress(4, "Erstelle sozialmedizinische Beurteilung...")
-    beurteilung_text = _step4_beurteilung(
+    # --- Schritt 4: Krankheitsbedingte Auswirkungen ---
+    _progress(4, "Erstelle krankheitsbedingte Auswirkungen...")
+    alltag, beruf, sozial = _step4_auswirkungen(
         client,
         raw_data.get("diagnosen", []),
         befund_text,
-        anamnese_text,
+        raw_data.get("auswirkungen_stichpunkte", {}),
     )
+
+    # Behandlungen formatieren
+    behandlungen_text = _format_behandlungen(raw_data.get("behandlungen", {}))
 
     return {
         "raw_data": raw_data,
         "diagnosen": raw_data.get("diagnosen", []),
         "befund_text": befund_text,
         "medikation": raw_data.get("medikation", []),
-        "anamnese_text": anamnese_text,
-        "beurteilung_text": beurteilung_text,
+        "verlauf": raw_data.get("verlauf", {}),
+        "verlauf_text": verlauf_text,
+        "sucht": raw_data.get("sucht", {}),
+        "sucht_text": sucht_text,
+        "behandlungen_text": behandlungen_text,
+        "auswirkungen_alltag": alltag,
+        "auswirkungen_beruf": beruf,
+        "auswirkungen_sozial": sozial,
     }
 
 
@@ -92,7 +114,6 @@ def _step1_extract(client: OllamaClient, patient_text: str) -> dict:
     try:
         data = client.extract_json(prompt)
     except ValueError:
-        # Fallback: leere Struktur
         data = dict(EMPTY_EXTRACTION)
 
     # Sicherstellen, dass alle AMDP-Kategorien vorhanden sind
@@ -102,15 +123,21 @@ def _step1_extract(client: OllamaClient, patient_text: str) -> dict:
             befund[key] = "nicht erhoben"
     data["befund"] = befund
 
-    # Sicherstellen, dass Listen vorhanden sind
+    # Sicherstellen, dass alle Top-Level-Schlüssel vorhanden sind
     if not isinstance(data.get("diagnosen"), list):
         data["diagnosen"] = []
     if not isinstance(data.get("medikation"), list):
         data["medikation"] = []
     if not isinstance(data.get("anamnese_stichpunkte"), list):
         data["anamnese_stichpunkte"] = []
-    if not isinstance(data.get("beurteilung_stichpunkte"), list):
-        data["beurteilung_stichpunkte"] = []
+    if not isinstance(data.get("verlauf"), dict):
+        data["verlauf"] = EMPTY_EXTRACTION["verlauf"]
+    if not isinstance(data.get("sucht"), dict):
+        data["sucht"] = {"vorhanden": False}
+    if not isinstance(data.get("behandlungen"), dict):
+        data["behandlungen"] = EMPTY_EXTRACTION["behandlungen"]
+    if not isinstance(data.get("auswirkungen_stichpunkte"), dict):
+        data["auswirkungen_stichpunkte"] = EMPTY_EXTRACTION["auswirkungen_stichpunkte"]
 
     return data
 
@@ -124,7 +151,6 @@ def _step2_amdp(client: OllamaClient, befund: dict) -> str:
 
     # Sicherstellen, dass der Text mit "Pat." beginnt
     if text and not text.startswith("Pat."):
-        # Versuche "Pat." am Anfang zu finden und alles davor zu entfernen
         idx = text.find("Pat.")
         if idx != -1:
             text = text[idx:]
@@ -134,37 +160,137 @@ def _step2_amdp(client: OllamaClient, befund: dict) -> str:
     return text or "[BITTE ERGÄNZEN]"
 
 
-def _step3_anamnese(client: OllamaClient, stichpunkte: list) -> str:
-    """Schritt 3: Generiert Anamnese-Fließtext aus Stichpunkten."""
-    if not stichpunkte:
-        return "[BITTE ERGÄNZEN]"
-
-    stichpunkte_text = "\n".join(f"- {s}" for s in stichpunkte)
-    prompt = ANAMNESE_PROMPT.format(stichpunkte=stichpunkte_text)
-
-    text = client.generate(prompt)
-    return text or "[BITTE ERGÄNZEN]"
-
-
-def _step4_beurteilung(
+def _step3_verlauf(
     client: OllamaClient,
-    diagnosen: list,
-    befund_text: str,
-    anamnese_text: str,
-) -> str:
-    """Schritt 4: Generiert sozialmedizinische Beurteilung."""
-    if not diagnosen:
-        diagnosen_text = "Keine Diagnosen extrahiert."
-    else:
-        diagnosen_text = "\n".join(
-            f"- {d.get('icd', '?')} – {d.get('text', '?')}" for d in diagnosen
-        )
+    anamnese_stichpunkte: list,
+    sucht: dict,
+    verlauf: dict,
+) -> tuple[str, str]:
+    """Schritt 3: Generiert Verlauf- und Suchtanamnese-Text.
 
-    prompt = BEURTEILUNG_PROMPT.format(
-        diagnosen=diagnosen_text,
-        befund_zusammenfassung=befund_text[:500] if befund_text else "Kein Befund.",
-        anamnese_zusammenfassung=anamnese_text[:500] if anamnese_text else "Keine Anamnese.",
+    Returns:
+        Tuple (verlauf_text, sucht_text)
+    """
+    stichpunkte = (
+        "\n".join(f"- {s}" for s in anamnese_stichpunkte)
+        if anamnese_stichpunkte
+        else "Keine Stichpunkte extrahiert."
+    )
+
+    sucht_daten = json.dumps(sucht, ensure_ascii=False, indent=2)
+    verlauf_daten = json.dumps(verlauf, ensure_ascii=False, indent=2)
+
+    prompt = VERLAUF_PROMPT.format(
+        anamnese_stichpunkte=stichpunkte,
+        sucht_daten=sucht_daten,
+        verlauf_daten=verlauf_daten,
     )
 
     text = client.generate(prompt)
-    return text or "[BITTE ERGÄNZEN]"
+
+    # Versuche den Text in Verlauf und Sucht zu splitten
+    verlauf_text = text or "[BITTE ERGÄNZEN]"
+    sucht_text = ""
+
+    if sucht.get("vorhanden"):
+        # Wenn Suchterkrankung vorhanden, versuche den Text aufzuteilen
+        # Der LLM sollte beides zusammen liefern
+        sucht_text = verlauf_text  # Fallback: gleicher Text
+    else:
+        sucht_text = "Keine Suchterkrankung bekannt."
+
+    return verlauf_text, sucht_text
+
+
+def _step4_auswirkungen(
+    client: OllamaClient,
+    diagnosen: list,
+    befund_text: str,
+    auswirkungen_stichpunkte: dict,
+) -> tuple[str, str, str]:
+    """Schritt 4: Generiert die drei Auswirkungs-Texte.
+
+    Returns:
+        Tuple (alltag, beruf, sozial)
+    """
+    diagnosen_text = (
+        "\n".join(f"- {d.get('icd', '?')} – {d.get('text', '?')}" for d in diagnosen)
+        if diagnosen
+        else "Keine Diagnosen extrahiert."
+    )
+
+    alltag_sp = auswirkungen_stichpunkte.get("alltag", [])
+    beruf_sp = auswirkungen_stichpunkte.get("beruf", [])
+    sozial_sp = auswirkungen_stichpunkte.get("sozial", [])
+
+    prompt = AUSWIRKUNGEN_PROMPT.format(
+        diagnosen=diagnosen_text,
+        befund_zusammenfassung=befund_text[:500] if befund_text else "Kein Befund.",
+        alltag_stichpunkte=", ".join(alltag_sp) if alltag_sp else "nicht erhoben",
+        beruf_stichpunkte=", ".join(beruf_sp) if beruf_sp else "nicht erhoben",
+        sozial_stichpunkte=", ".join(sozial_sp) if sozial_sp else "nicht erhoben",
+    )
+
+    text = client.generate(prompt)
+
+    # Parse die drei Bereiche
+    alltag = "[BITTE ERGÄNZEN]"
+    beruf = "[BITTE ERGÄNZEN]"
+    sozial = "[BITTE ERGÄNZEN]"
+
+    if text:
+        if "---ALLTAG---" in text and "---BERUF---" in text and "---SOZIAL---" in text:
+            parts = text.split("---ALLTAG---")
+            if len(parts) > 1:
+                rest = parts[1]
+                parts2 = rest.split("---BERUF---")
+                if len(parts2) > 1:
+                    alltag = parts2[0].strip()
+                    rest2 = parts2[1]
+                    parts3 = rest2.split("---SOZIAL---")
+                    if len(parts3) > 1:
+                        beruf = parts3[0].strip()
+                        sozial = parts3[1].strip()
+        else:
+            # Fallback: gesamten Text als Alltag verwenden
+            alltag = text.strip()
+
+    return alltag, beruf, sozial
+
+
+def _format_behandlungen(behandlungen: dict) -> str:
+    """Formatiert die extrahierten Behandlungen als Text."""
+    lines = []
+
+    stationaer = behandlungen.get("stationaer", [])
+    if stationaer:
+        lines.append("Vollstationär psychiatrisch:")
+        for b in stationaer:
+            if isinstance(b, str) and b != "nicht erhoben":
+                lines.append(f"  {b}")
+
+    reha = behandlungen.get("reha", [])
+    if reha:
+        lines.append("Rehabilitationsbehandlung:")
+        for b in reha:
+            if isinstance(b, str) and b != "nicht erhoben":
+                lines.append(f"  {b}")
+
+    teilstationaer = behandlungen.get("teilstationaer", [])
+    if teilstationaer:
+        lines.append("Teilstationär (Tagesklinik):")
+        for b in teilstationaer:
+            if isinstance(b, str) and b != "nicht erhoben":
+                lines.append(f"  {b}")
+
+    ambulant = behandlungen.get("ambulant", [])
+    if ambulant:
+        lines.append("Ambulante Psychotherapie:")
+        for b in ambulant:
+            if isinstance(b, str) and b != "nicht erhoben":
+                lines.append(f"  {b}")
+
+    if not lines:
+        return "Keine im geforderten Zeitraum."
+
+    return "\n".join(lines)

--- a/lageso_agent/extractor.py
+++ b/lageso_agent/extractor.py
@@ -1,0 +1,170 @@
+"""
+Multi-Step Extraktion: Rohtext → strukturierte Daten → Fließtexte.
+Orchestriert die 4-Schritt-LLM-Pipeline.
+"""
+
+import json
+from typing import Callable, Optional
+
+from llm_client import OllamaClient
+from prompts import (
+    AMDP_KATEGORIEN,
+    AMDP_PROMPT,
+    ANAMNESE_PROMPT,
+    BEURTEILUNG_PROMPT,
+    EXTRACTION_PROMPT,
+)
+
+
+# Leeres Befund-Template (Fallback)
+EMPTY_BEFUND = {k: "nicht erhoben" for k in AMDP_KATEGORIEN}
+
+EMPTY_EXTRACTION = {
+    "diagnosen": [],
+    "befund": dict(EMPTY_BEFUND),
+    "medikation": [],
+    "anamnese_stichpunkte": [],
+    "beurteilung_stichpunkte": [],
+}
+
+
+def extract_data(
+    client: OllamaClient,
+    patient_text: str,
+    progress_callback: Optional[Callable[[int, str], None]] = None,
+) -> dict:
+    """Führt die vollständige 4-Schritt-Extraktion durch.
+
+    Args:
+        client: OllamaClient-Instanz
+        patient_text: Unstrukturierter klinischer Text
+        progress_callback: Optional callback(step_number, step_description)
+
+    Returns:
+        Dict mit Schlüsseln:
+        - raw_data: Extrahierte Rohdaten (JSON)
+        - vorstellung: Vorstellungsdaten (aus Metadaten)
+        - diagnosen: Liste der Diagnosen
+        - befund_text: AMDP-Fließtext
+        - medikation: Medikationsliste
+        - anamnese_text: Anamnese-Fließtext
+        - beurteilung_text: Beurteilungs-Fließtext
+    """
+
+    def _progress(step: int, desc: str):
+        if progress_callback:
+            progress_callback(step, desc)
+
+    # --- Schritt 1: Extraktion ---
+    _progress(1, "Extrahiere Informationen aus dem Text...")
+    raw_data = _step1_extract(client, patient_text)
+
+    # --- Schritt 2: AMDP-Fließtext ---
+    _progress(2, "Erstelle psychopathologischen Befund (AMDP)...")
+    befund_text = _step2_amdp(client, raw_data.get("befund", EMPTY_BEFUND))
+
+    # --- Schritt 3: Anamnese-Fließtext ---
+    _progress(3, "Erstelle Anamnese und Behandlungsverlauf...")
+    anamnese_text = _step3_anamnese(client, raw_data.get("anamnese_stichpunkte", []))
+
+    # --- Schritt 4: Beurteilung ---
+    _progress(4, "Erstelle sozialmedizinische Beurteilung...")
+    beurteilung_text = _step4_beurteilung(
+        client,
+        raw_data.get("diagnosen", []),
+        befund_text,
+        anamnese_text,
+    )
+
+    return {
+        "raw_data": raw_data,
+        "diagnosen": raw_data.get("diagnosen", []),
+        "befund_text": befund_text,
+        "medikation": raw_data.get("medikation", []),
+        "anamnese_text": anamnese_text,
+        "beurteilung_text": beurteilung_text,
+    }
+
+
+def _step1_extract(client: OllamaClient, patient_text: str) -> dict:
+    """Schritt 1: Extrahiert strukturierte Daten aus dem Rohtext."""
+    prompt = EXTRACTION_PROMPT.format(patient_text=patient_text)
+    try:
+        data = client.extract_json(prompt)
+    except ValueError:
+        # Fallback: leere Struktur
+        data = dict(EMPTY_EXTRACTION)
+
+    # Sicherstellen, dass alle AMDP-Kategorien vorhanden sind
+    befund = data.get("befund", {})
+    for key in AMDP_KATEGORIEN:
+        if key not in befund or not befund[key]:
+            befund[key] = "nicht erhoben"
+    data["befund"] = befund
+
+    # Sicherstellen, dass Listen vorhanden sind
+    if not isinstance(data.get("diagnosen"), list):
+        data["diagnosen"] = []
+    if not isinstance(data.get("medikation"), list):
+        data["medikation"] = []
+    if not isinstance(data.get("anamnese_stichpunkte"), list):
+        data["anamnese_stichpunkte"] = []
+    if not isinstance(data.get("beurteilung_stichpunkte"), list):
+        data["beurteilung_stichpunkte"] = []
+
+    return data
+
+
+def _step2_amdp(client: OllamaClient, befund: dict) -> str:
+    """Schritt 2: Generiert AMDP-Fließtext aus den Befunddaten."""
+    befund_json = json.dumps(befund, ensure_ascii=False, indent=2)
+    prompt = AMDP_PROMPT.format(befund_json=befund_json)
+
+    text = client.generate(prompt)
+
+    # Sicherstellen, dass der Text mit "Pat." beginnt
+    if text and not text.startswith("Pat."):
+        # Versuche "Pat." am Anfang zu finden und alles davor zu entfernen
+        idx = text.find("Pat.")
+        if idx != -1:
+            text = text[idx:]
+        else:
+            text = "Pat. " + text
+
+    return text or "[BITTE ERGÄNZEN]"
+
+
+def _step3_anamnese(client: OllamaClient, stichpunkte: list) -> str:
+    """Schritt 3: Generiert Anamnese-Fließtext aus Stichpunkten."""
+    if not stichpunkte:
+        return "[BITTE ERGÄNZEN]"
+
+    stichpunkte_text = "\n".join(f"- {s}" for s in stichpunkte)
+    prompt = ANAMNESE_PROMPT.format(stichpunkte=stichpunkte_text)
+
+    text = client.generate(prompt)
+    return text or "[BITTE ERGÄNZEN]"
+
+
+def _step4_beurteilung(
+    client: OllamaClient,
+    diagnosen: list,
+    befund_text: str,
+    anamnese_text: str,
+) -> str:
+    """Schritt 4: Generiert sozialmedizinische Beurteilung."""
+    if not diagnosen:
+        diagnosen_text = "Keine Diagnosen extrahiert."
+    else:
+        diagnosen_text = "\n".join(
+            f"- {d.get('icd', '?')} – {d.get('text', '?')}" for d in diagnosen
+        )
+
+    prompt = BEURTEILUNG_PROMPT.format(
+        diagnosen=diagnosen_text,
+        befund_zusammenfassung=befund_text[:500] if befund_text else "Kein Befund.",
+        anamnese_zusammenfassung=anamnese_text[:500] if anamnese_text else "Keine Anamnese.",
+    )
+
+    text = client.generate(prompt)
+    return text or "[BITTE ERGÄNZEN]"

--- a/lageso_agent/llm_client.py
+++ b/lageso_agent/llm_client.py
@@ -1,0 +1,185 @@
+"""
+Ollama-Client für den LaGeSo-Befundbericht-Generator.
+Kommuniziert mit dem lokalen Ollama-Server über HTTP.
+"""
+
+import json
+import re
+import requests
+from typing import Optional
+
+from prompts import SYSTEM_PROMPT
+
+DEFAULT_OLLAMA_URL = "http://localhost:11434"
+DEFAULT_MODEL = "llama3.1:8b"
+REQUEST_TIMEOUT = 120  # Sekunden
+
+
+class OllamaClient:
+    """Client für die Kommunikation mit Ollama."""
+
+    def __init__(self, base_url: str = DEFAULT_OLLAMA_URL, model: str = DEFAULT_MODEL):
+        self.base_url = base_url.rstrip("/")
+        self.model = model
+
+    def test_connection(self) -> tuple[bool, str]:
+        """Testet die Verbindung zum Ollama-Server.
+
+        Returns:
+            Tuple (Erfolg, Nachricht)
+        """
+        try:
+            resp = requests.get(f"{self.base_url}/api/tags", timeout=10)
+            if resp.status_code == 200:
+                models = [m["name"] for m in resp.json().get("models", [])]
+                if self.model in models:
+                    return True, f"Verbunden. Modell '{self.model}' verfügbar."
+                # Check for model name without tag
+                base_names = [m.split(":")[0] for m in models]
+                model_base = self.model.split(":")[0]
+                if model_base in base_names:
+                    return True, f"Verbunden. Modell '{self.model}' verfügbar."
+                available = ", ".join(models) if models else "keine"
+                return False, (
+                    f"Verbunden, aber Modell '{self.model}' nicht gefunden. "
+                    f"Verfügbare Modelle: {available}"
+                )
+            return False, f"Ollama antwortet mit Status {resp.status_code}"
+        except requests.ConnectionError:
+            return False, (
+                "Ollama ist nicht erreichbar. "
+                "Bitte starten Sie Ollama mit 'ollama serve'."
+            )
+        except requests.Timeout:
+            return False, "Zeitüberschreitung bei Verbindung zu Ollama."
+        except Exception as e:
+            return False, f"Verbindungsfehler: {str(e)}"
+
+    def generate(self, prompt: str, system: Optional[str] = None) -> str:
+        """Sendet einen Prompt an Ollama und gibt die Antwort zurück.
+
+        Args:
+            prompt: Der User-Prompt
+            system: Optionaler System-Prompt (Default: SYSTEM_PROMPT)
+
+        Returns:
+            Die generierte Antwort als String
+
+        Raises:
+            ConnectionError: Wenn Ollama nicht erreichbar ist
+            TimeoutError: Bei Zeitüberschreitung
+            RuntimeError: Bei sonstigen Fehlern
+        """
+        if system is None:
+            system = SYSTEM_PROMPT
+
+        payload = {
+            "model": self.model,
+            "prompt": prompt,
+            "system": system,
+            "stream": False,
+            "options": {
+                "temperature": 0.3,
+                "num_predict": 4096,
+            },
+        }
+
+        try:
+            resp = requests.post(
+                f"{self.base_url}/api/generate",
+                json=payload,
+                timeout=REQUEST_TIMEOUT,
+            )
+            resp.raise_for_status()
+            return resp.json().get("response", "").strip()
+        except requests.ConnectionError:
+            raise ConnectionError(
+                "Ollama ist nicht erreichbar. "
+                "Bitte starten Sie Ollama mit 'ollama serve'."
+            )
+        except requests.Timeout:
+            raise TimeoutError(
+                f"Zeitüberschreitung ({REQUEST_TIMEOUT}s) bei LLM-Aufruf. "
+                "Versuchen Sie es erneut oder verwenden Sie ein kleineres Modell."
+            )
+        except requests.HTTPError as e:
+            raise RuntimeError(f"Ollama HTTP-Fehler: {e}")
+
+    def extract_json(self, prompt: str, max_retries: int = 3) -> dict:
+        """Sendet einen Prompt und extrahiert JSON aus der Antwort.
+
+        Versucht bis zu max_retries Mal, valides JSON zu erhalten.
+
+        Args:
+            prompt: Der Prompt, der JSON-Ausgabe erwartet
+            max_retries: Maximale Anzahl an Versuchen
+
+        Returns:
+            Geparstes JSON als dict
+
+        Raises:
+            ValueError: Wenn nach allen Versuchen kein valides JSON
+        """
+        last_error = None
+        for attempt in range(max_retries):
+            try:
+                raw = self.generate(prompt)
+                return self._parse_json(raw)
+            except (json.JSONDecodeError, ValueError) as e:
+                last_error = e
+                if attempt < max_retries - 1:
+                    # Retry mit klarerer Anweisung
+                    prompt = (
+                        f"Deine vorherige Antwort war kein valides JSON. "
+                        f"Fehler: {str(e)}\n\n"
+                        f"Bitte antworte NUR mit einem validen JSON-Objekt, "
+                        f"KEIN anderer Text davor oder danach.\n\n"
+                        f"Ursprüngliche Aufgabe:\n{prompt}"
+                    )
+
+        raise ValueError(
+            f"Konnte nach {max_retries} Versuchen kein valides JSON extrahieren. "
+            f"Letzter Fehler: {last_error}"
+        )
+
+    @staticmethod
+    def _parse_json(text: str) -> dict:
+        """Versucht JSON aus einem Text zu extrahieren.
+
+        Unterstützt:
+        - Reines JSON
+        - JSON in ```json ... ``` Code-Blöcken
+        - JSON eingebettet in Text (findet erstes { ... } Paar)
+        """
+        text = text.strip()
+
+        # Versuch 1: Direktes Parsen
+        try:
+            return json.loads(text)
+        except json.JSONDecodeError:
+            pass
+
+        # Versuch 2: JSON aus Code-Block extrahieren
+        code_block = re.search(r"```(?:json)?\s*\n?(.*?)\n?```", text, re.DOTALL)
+        if code_block:
+            try:
+                return json.loads(code_block.group(1).strip())
+            except json.JSONDecodeError:
+                pass
+
+        # Versuch 3: Erstes JSON-Objekt finden (Klammer-Matching)
+        brace_start = text.find("{")
+        if brace_start != -1:
+            depth = 0
+            for i in range(brace_start, len(text)):
+                if text[i] == "{":
+                    depth += 1
+                elif text[i] == "}":
+                    depth -= 1
+                    if depth == 0:
+                        try:
+                            return json.loads(text[brace_start : i + 1])
+                        except json.JSONDecodeError:
+                            break
+
+        raise ValueError(f"Kein valides JSON in der Antwort gefunden.")

--- a/lageso_agent/prompts.py
+++ b/lageso_agent/prompts.py
@@ -1,0 +1,155 @@
+"""
+Prompt-Templates für den LaGeSo-Befundbericht-Generator.
+Alle Prompts als Konstanten – zentrale Verwaltung.
+"""
+
+SYSTEM_PROMPT = """Du bist ein medizinischer Dokumentationsassistent für psychiatrische Befundberichte nach dem Standard von Dr. med. Carsten Urbanek (CU-Standard).
+
+REGELN:
+- Schreibe IMMER auf Deutsch in medizinischer Fachsprache
+- Fließtext, NIEMALS Aufzählungszeichen oder Markdown im Berichtstext
+- AMDP-Befund: Alle 20 Kategorien in exakter Reihenfolge (Bewusstsein → Orientierung → Aufmerksamkeit → Gedächtnis → Formales Denken → Befürchtungen → Wahn → Sinnestäuschungen → Ich-Störungen → Zwänge → Phobien → Affektivität → Antrieb → Psychomotorik → Circadiane Rhythmik → Schlaf → Appetit → Gewicht → Suizidalität → Eigen-/Fremdgefährdung)
+- Beginne den AMDP-Befund IMMER mit "Pat."
+- ICD-10 Codes: Immer vollständig mit Untergruppe (z.B. F33.2, nicht nur F33)
+- Medikation: NUR Psychopharmaka, KEINE somatische Medikation
+- Medikamente in GROSSBUCHSTABEN
+- Dosierungsschema: Format "X-X-X-X" (morgens-mittags-abends-nachts)
+- Keine Spekulationen – nur was aus dem Quelltext hervorgeht
+- Fehlende Informationen als "nicht erhoben" / "nicht beurteilbar" kennzeichnen"""
+
+EXTRACTION_PROMPT = """Extrahiere aus dem folgenden klinischen Text alle relevanten Informationen und gib sie als JSON zurück.
+
+Antworte NUR mit dem JSON-Objekt, KEIN weiterer Text davor oder danach.
+
+Erwartetes Format:
+{{
+  "diagnosen": [{{"icd": "...", "text": "..."}}],
+  "befund": {{
+    "bewusstsein": "...",
+    "orientierung": "...",
+    "aufmerksamkeit": "...",
+    "gedaechtnis": "...",
+    "formales_denken": "...",
+    "befuerchtungen": "...",
+    "wahn": "...",
+    "sinnestaueschungen": "...",
+    "ich_stoerungen": "...",
+    "zwang": "...",
+    "phobie": "...",
+    "affektivitaet": "...",
+    "antrieb": "...",
+    "psychomotorik": "...",
+    "circadiane_rhythmik": "...",
+    "schlaf": "...",
+    "appetit": "...",
+    "gewicht_bmi": "...",
+    "suizidalitaet": "...",
+    "eigen_fremdgefaehrdung": "..."
+  }},
+  "medikation": [{{"name": "...", "dosis": "...", "schema": "..."}}],
+  "anamnese_stichpunkte": ["..."],
+  "beurteilung_stichpunkte": ["..."]
+}}
+
+Wenn eine Information nicht im Text vorkommt, setze den Wert auf "nicht erhoben".
+NUR psychopharmakologische Medikation extrahieren, keine somatische.
+ICD-10 Codes immer vollständig mit Untergruppe angeben (z.B. F33.2, nicht nur F33).
+
+KLINISCHER TEXT:
+{patient_text}"""
+
+AMDP_PROMPT = """Erstelle aus den folgenden AMDP-Befunddaten einen medizinischen Fließtext für einen psychiatrischen Befundbericht.
+
+REGELN:
+- Alle 20 AMDP-Kategorien müssen in exakt dieser Reihenfolge vorkommen:
+  1. Bewusstsein, 2. Orientierung, 3. Aufmerksamkeit, 4. Gedächtnis,
+  5. Formales Denken, 6. Befürchtungen, 7. Wahn, 8. Sinnestäuschungen,
+  9. Ich-Störungen, 10. Zwänge, 11. Phobien, 12. Affektivität,
+  13. Antrieb, 14. Psychomotorik, 15. Circadiane Rhythmik, 16. Schlaf,
+  17. Appetit, 18. Gewicht/BMI, 19. Suizidalität, 20. Eigen-/Fremdgefährdung
+- Beginne IMMER mit "Pat."
+- Fließtext, KEINE Aufzählungszeichen, KEIN Markdown
+- Medizinische Fachsprache, knapp und präzise
+- Antworte NUR mit dem Fließtext, kein weiterer Text
+
+AMDP-BEFUNDDATEN:
+{befund_json}"""
+
+ANAMNESE_PROMPT = """Erstelle aus den folgenden Stichpunkten einen Anamnesetext für einen LaGeSo-Befundbericht.
+
+REGELN:
+- Fließtext, sachlich, medizinisch-fachsprachlich
+- KEINE Aufzählungszeichen, KEIN Markdown
+- Zusammenhängender, logisch strukturierter Text
+- Beginne NICHT mit einer Überschrift
+- Antworte NUR mit dem Fließtext, kein weiterer Text
+
+STICHPUNKTE:
+{stichpunkte}"""
+
+BEURTEILUNG_PROMPT = """Erstelle eine sozialmedizinische Beurteilung für einen LaGeSo-Befundbericht.
+
+REGELN:
+- Sachlich, fachsprachlich, Fließtext
+- KEINE Aufzählungszeichen, KEIN Markdown
+- Auf Basis der Diagnosen und Befunde
+- Beginne NICHT mit einer Überschrift
+- Beziehe dich auf die Auswirkungen der Erkrankung auf die Lebensführung und Teilhabe
+- Antworte NUR mit dem Fließtext, kein weiterer Text
+
+DIAGNOSEN:
+{diagnosen}
+
+BEFUND-ZUSAMMENFASSUNG:
+{befund_zusammenfassung}
+
+ANAMNESE-ZUSAMMENFASSUNG:
+{anamnese_zusammenfassung}"""
+
+# AMDP-Kategorien in korrekter Reihenfolge (für Validierung)
+AMDP_KATEGORIEN = [
+    "bewusstsein",
+    "orientierung",
+    "aufmerksamkeit",
+    "gedaechtnis",
+    "formales_denken",
+    "befuerchtungen",
+    "wahn",
+    "sinnestaueschungen",
+    "ich_stoerungen",
+    "zwang",
+    "phobie",
+    "affektivitaet",
+    "antrieb",
+    "psychomotorik",
+    "circadiane_rhythmik",
+    "schlaf",
+    "appetit",
+    "gewicht_bmi",
+    "suizidalitaet",
+    "eigen_fremdgefaehrdung",
+]
+
+# Lesbare deutsche Labels für AMDP-Kategorien
+AMDP_LABELS = {
+    "bewusstsein": "Bewusstsein",
+    "orientierung": "Orientierung",
+    "aufmerksamkeit": "Aufmerksamkeit",
+    "gedaechtnis": "Gedächtnis",
+    "formales_denken": "Formales Denken",
+    "befuerchtungen": "Befürchtungen",
+    "wahn": "Wahn",
+    "sinnestaueschungen": "Sinnestäuschungen",
+    "ich_stoerungen": "Ich-Störungen",
+    "zwang": "Zwänge",
+    "phobie": "Phobien",
+    "affektivitaet": "Affektivität",
+    "antrieb": "Antrieb",
+    "psychomotorik": "Psychomotorik",
+    "circadiane_rhythmik": "Circadiane Rhythmik",
+    "schlaf": "Schlaf",
+    "appetit": "Appetit",
+    "gewicht_bmi": "Gewicht/BMI",
+    "suizidalitaet": "Suizidalität",
+    "eigen_fremdgefaehrdung": "Eigen-/Fremdgefährdung",
+}

--- a/lageso_agent/prompts.py
+++ b/lageso_agent/prompts.py
@@ -109,11 +109,15 @@ KLINISCHER TEXT:
 {patient_text}"""
 
 # ---------------------------------------------------------------------------
-# Schritt 2: AMDP-Fließtext
+# Schritt 2: AMDP-Fließtext (DIRECT MODE - Originaltext wird mitgesendet)
 # ---------------------------------------------------------------------------
 AMDP_PROMPT = """\
-Erstelle aus den folgenden AMDP-Befunddaten einen medizinischen Fließtext \
-für einen psychiatrischen Befundbericht nach dem CU-Standard.
+Erstelle den psychopathologischen Befund (AMDP-System) als Fließtext \
+für einen LaGeSo-Befundbericht nach dem CU-Standard.
+
+Lies den ORIGINALEN KLINISCHEN TEXT sorgfältig und erstelle daraus den \
+AMDP-Befund. Die vorextrahierten Stichpunkte dienen nur als Orientierung - \
+nutze IMMER den Originaltext als primäre Quelle.
 
 REGELN:
 - ALLE 20 Kategorien in EXAKT dieser Reihenfolge:
@@ -129,6 +133,7 @@ REGELN:
 - Fließtext mit Punkten als Satzzeichen, KEINE Aufzählungszeichen, KEIN Markdown
 - KEINE Nummerierung
 - Medizinische Fachsprache, knapp und präzise, auf Deutsch
+- Fehlende Informationen als "nicht erhoben" / "nicht beurteilbar" kennzeichnen
 - Antworte NUR mit dem Fließtext, kein weiterer Text
 
 BEISPIEL-FORMAT:
@@ -142,15 +147,22 @@ Gewichtsabnahme in den letzten Monaten. BMI 21. Keine akute Suizidalität. \
 Keine akute Eigen- oder Fremdgefährdung. Psychopharmakologische Vorbehandlung \
 mit Escitalopram."
 
-AMDP-BEFUNDDATEN:
+=== ORIGINALER KLINISCHER TEXT (PRIMÄRE QUELLE) ===
+{patient_text}
+
+=== VOREXTRAHIERTE STICHPUNKTE (nur Orientierung) ===
 {befund_json}"""
 
 # ---------------------------------------------------------------------------
-# Schritt 3: Verlauf + Suchtanamnese
+# Schritt 3: Verlauf + Suchtanamnese (DIRECT MODE - Originaltext wird mitgesendet)
 # ---------------------------------------------------------------------------
 VERLAUF_PROMPT = """\
-Erstelle aus den folgenden Stichpunkten einen Text für den Abschnitt \
-"Verlauf der Erkrankung" und ggf. "Suchterkrankung" eines LaGeSo-Befundberichts.
+Erstelle den Abschnitt "Verlauf der Erkrankung" und ggf. "Suchterkrankung" \
+für einen LaGeSo-Befundbericht.
+
+Lies den ORIGINALEN KLINISCHEN TEXT sorgfältig und erstelle daraus den \
+Verlaufstext. Die vorextrahierten Stichpunkte dienen nur als Orientierung - \
+nutze IMMER den Originaltext als primäre Quelle.
 
 REGELN:
 - Fließtext, sachlich, medizinisch-fachsprachlich, auf Deutsch
@@ -158,38 +170,43 @@ REGELN:
 - Zusammenhängender, logisch strukturierter Text
 - Bei Suchterkrankung: ALLE 6 Punkte abdecken (Konsummuster, letzter Konsum, \
 Entzugssymptomatik, stationäre Behandlung, Abstinenzstatus, aktuelle Anbindung)
+- NUR psychiatrische/psychotherapeutische Behandlungen erwähnen
+- KEINE Physiotherapie, Orthopädie oder somatische Behandlungen
+- Nur dokumentierte Fakten, keine Spekulationen
 - Antworte NUR mit dem Fließtext, kein weiterer Text
 
-ANAMNESE/VERLAUF-STICHPUNKTE:
-{anamnese_stichpunkte}
+=== ORIGINALER KLINISCHER TEXT (PRIMÄRE QUELLE) ===
+{patient_text}
 
-SUCHTERKRANKUNG-DATEN:
-{sucht_daten}
-
-VERLAUFSINFORMATIONEN:
-{verlauf_daten}"""
+=== VOREXTRAHIERTE STICHPUNKTE (nur Orientierung) ===
+Anamnese: {anamnese_stichpunkte}
+Sucht: {sucht_daten}
+Verlauf: {verlauf_daten}"""
 
 # ---------------------------------------------------------------------------
-# Schritt 4: Krankheitsbedingte Auswirkungen
+# Schritt 4: Krankheitsbedingte Auswirkungen (DIRECT MODE - Originaltext wird mitgesendet)
 # ---------------------------------------------------------------------------
 AUSWIRKUNGEN_PROMPT = """\
 Erstelle für einen LaGeSo-Befundbericht die drei Abschnitte der \
 "Krankheitsbedingten Auswirkungen" (Alltag, Beruf, Sozial).
+
+Lies den ORIGINALEN KLINISCHEN TEXT sorgfältig und erstelle daraus die \
+Auswirkungstexte. Die vorextrahierten Stichpunkte dienen nur als Orientierung - \
+nutze IMMER den Originaltext als primäre Quelle.
 
 REGELN:
 - Sachlich, fachsprachlich, Fließtext, auf Deutsch
 - KEINE Aufzählungszeichen, KEIN Markdown
 - Für jeden Bereich (Alltag, Beruf, Sozial) einen separaten Absatz
 - Trenne die drei Bereiche mit genau "---ALLTAG---", "---BERUF---", "---SOZIAL---"
+- Nur dokumentierte Fakten aus dem Text, keine Spekulationen
 - Antworte NUR mit den drei Absätzen, kein weiterer Text
 
-DIAGNOSEN:
-{diagnosen}
+=== ORIGINALER KLINISCHER TEXT (PRIMÄRE QUELLE) ===
+{patient_text}
 
-BEFUND-ZUSAMMENFASSUNG:
-{befund_zusammenfassung}
-
-STICHPUNKTE ZU AUSWIRKUNGEN:
+=== VOREXTRAHIERTE STICHPUNKTE (nur Orientierung) ===
+Diagnosen: {diagnosen}
 Alltag: {alltag_stichpunkte}
 Beruf: {beruf_stichpunkte}
 Sozial: {sozial_stichpunkte}"""

--- a/lageso_agent/prompts.py
+++ b/lageso_agent/prompts.py
@@ -1,23 +1,41 @@
 """
 Prompt-Templates für den LaGeSo-Befundbericht-Generator.
 Alle Prompts als Konstanten – zentrale Verwaltung.
+Basiert auf der CU-Standard Wissensdatenbank (Version 2.0, Februar 2026).
 """
 
-SYSTEM_PROMPT = """Du bist ein medizinischer Dokumentationsassistent für psychiatrische Befundberichte nach dem Standard von Dr. med. Carsten Urbanek (CU-Standard).
+SYSTEM_PROMPT = """\
+Du bist ein spezialisierter medizinischer Assistent für die Erstellung \
+psychiatrischer Befundberichte für das Landesamt für Gesundheit und Soziales \
+(LaGeSo) Berlin nach den Standards von Dr. med. Carsten Urbanek, \
+Facharzt für Psychiatrie und Psychotherapie.
 
-REGELN:
-- Schreibe IMMER auf Deutsch in medizinischer Fachsprache
-- Fließtext, NIEMALS Aufzählungszeichen oder Markdown im Berichtstext
-- AMDP-Befund: Alle 20 Kategorien in exakter Reihenfolge (Bewusstsein → Orientierung → Aufmerksamkeit → Gedächtnis → Formales Denken → Befürchtungen → Wahn → Sinnestäuschungen → Ich-Störungen → Zwänge → Phobien → Affektivität → Antrieb → Psychomotorik → Circadiane Rhythmik → Schlaf → Appetit → Gewicht → Suizidalität → Eigen-/Fremdgefährdung)
+KRITISCHE REGELN:
+- Schreibe IMMER auf Deutsch in medizinischer Fachsprache, KEIN Denglisch
+- AMDP-Befund: IMMER als Fließtext, NIEMALS nummeriert oder als Liste
+- AMDP-Befund: ALLE 20 Kategorien in EXAKTER CU-Reihenfolge:
+  1. Bewusstseinslage → 2. Stimmung → 3. Affekt → 4. Konzentration →
+  5. Merkfähigkeit/Gedächtnis → 6. Interesse → 7. Formales Denken →
+  8. Inhaltliches Denken → 9+10. Wahrnehmung UND Ich-Störungen (zusammen!) →
+  11. Zwänge/Phobien → 12. Antrieb → 13. Psychomotorik → 14. Schlaf →
+  15. Appetit → 16. Gewicht → 17. BMI (separat!) → 18. Suizidalität →
+  19. Eigen-/Fremdgefährdung → 20. Psychopharmakologische Vorbehandlung
 - Beginne den AMDP-Befund IMMER mit "Pat."
-- ICD-10 Codes: Immer vollständig mit Untergruppe (z.B. F33.2, nicht nur F33)
+- ICD-10 Codes: Exakte ICD-10-Terminologie mit Untergruppe (z.B. F33.2)
+  ACHTUNG: F33.3 = MIT psychotischen Symptomen, F33.2 = OHNE psychotische Symptome
 - Medikation: NUR Psychopharmaka, KEINE somatische Medikation
-- Medikamente in GROSSBUCHSTABEN
-- Dosierungsschema: Format "X-X-X-X" (morgens-mittags-abends-nachts)
-- Keine Spekulationen – nur was aus dem Quelltext hervorgeht
-- Fehlende Informationen als "nicht erhoben" / "nicht beurteilbar" kennzeichnen"""
+- Medikamente in GROSSBUCHSTABEN, Schema: "X-X-X-X" (morgens-mittags-abends-nachts)
+- Behandlungen: NUR psychiatrische/psychotherapeutische, KEINE Physiotherapie/Orthopädie
+- Keine Spekulationen – nur dokumentierte Fakten
+- Fehlende Informationen als "nicht erhoben" / "[FEHLT]" kennzeichnen
+- Zeitraum: maximal 2 Jahre (seit Dezember 2024)"""
 
-EXTRACTION_PROMPT = """Extrahiere aus dem folgenden klinischen Text alle relevanten Informationen und gib sie als JSON zurück.
+# ---------------------------------------------------------------------------
+# Schritt 1: Extraktion
+# ---------------------------------------------------------------------------
+EXTRACTION_PROMPT = """\
+Extrahiere aus dem folgenden klinischen Text alle relevanten Informationen \
+und gib sie als JSON zurück.
 
 Antworte NUR mit dem JSON-Objekt, KEIN weiterer Text davor oder danach.
 
@@ -25,77 +43,145 @@ Erwartetes Format:
 {{
   "diagnosen": [{{"icd": "...", "text": "..."}}],
   "befund": {{
-    "bewusstsein": "...",
-    "orientierung": "...",
-    "aufmerksamkeit": "...",
-    "gedaechtnis": "...",
+    "bewusstseinslage": "...",
+    "stimmung": "...",
+    "affekt": "...",
+    "konzentration": "...",
+    "merkfaehigkeit_gedaechtnis": "...",
+    "interesse": "...",
     "formales_denken": "...",
-    "befuerchtungen": "...",
-    "wahn": "...",
-    "sinnestaueschungen": "...",
-    "ich_stoerungen": "...",
-    "zwang": "...",
-    "phobie": "...",
-    "affektivitaet": "...",
+    "inhaltliches_denken": "...",
+    "wahrnehmung_ich_stoerungen": "...",
+    "zwaenge_phobien": "...",
     "antrieb": "...",
     "psychomotorik": "...",
-    "circadiane_rhythmik": "...",
     "schlaf": "...",
     "appetit": "...",
-    "gewicht_bmi": "...",
+    "gewicht": "...",
+    "bmi": "...",
     "suizidalitaet": "...",
-    "eigen_fremdgefaehrdung": "..."
+    "eigen_fremdgefaehrdung": "...",
+    "psychopharm_vorbehandlung": "..."
   }},
-  "medikation": [{{"name": "...", "dosis": "...", "schema": "..."}}],
-  "anamnese_stichpunkte": ["..."],
-  "beurteilung_stichpunkte": ["..."]
+  "medikation": [{{"datum": "...", "name": "...", "dosis": "...", "schema": "..."}}],
+  "verlauf": {{
+    "form": "dauerhaft oder phasenhaft",
+    "tendenz": "chronifizierend oder stabil oder progredient",
+    "behandlungserfolg": "verbesserung oder gleichbleibend oder verschlechterung"
+  }},
+  "sucht": {{
+    "vorhanden": true,
+    "konsummuster": "...",
+    "letzter_konsum": "...",
+    "entzugssymptomatik": "...",
+    "stationaere_behandlung": "...",
+    "abstinenz_seit": "...",
+    "aktuelle_anbindung": "..."
+  }},
+  "behandlungen": {{
+    "stationaer": ["..."],
+    "teilstationaer": ["..."],
+    "ambulant": ["..."],
+    "reha": ["..."]
+  }},
+  "auswirkungen_stichpunkte": {{
+    "alltag": ["..."],
+    "beruf": ["..."],
+    "sozial": ["..."]
+  }},
+  "anamnese_stichpunkte": ["..."]
 }}
 
-Wenn eine Information nicht im Text vorkommt, setze den Wert auf "nicht erhoben".
-NUR psychopharmakologische Medikation extrahieren, keine somatische.
-ICD-10 Codes immer vollständig mit Untergruppe angeben (z.B. F33.2, nicht nur F33).
+WICHTIGE REGELN:
+- Wenn eine Information nicht im Text vorkommt, setze den Wert auf "nicht erhoben"
+- NUR psychopharmakologische Medikation extrahieren (KEINE somatische wie \
+Levothyroxin, Blutdruckmedikamente, Schmerzmittel)
+- ICD-10 Codes IMMER vollständig mit Untergruppe (z.B. F33.2, nicht nur F33)
+- ACHTUNG: F33.3 = MIT psychotischen Symptomen, F33.2 = OHNE
+- F45.1 = "Undifferenzierte Somatisierungsstörung" (NICHT "Somatische Symptomstörung")
+- Medikamentennamen in GROSSBUCHSTABEN
+- NUR psychiatrische/psychotherapeutische Behandlungen, KEINE Physiotherapie
+- Bei Suchterkrankung: Alle 6 Punkte extrahieren (Konsummuster, letzter Konsum, \
+Entzugssymptomatik, stationäre Behandlung, Abstinenzstatus, aktuelle Anbindung)
+- Wenn keine Suchterkrankung: {{"vorhanden": false}} setzen
 
 KLINISCHER TEXT:
 {patient_text}"""
 
-AMDP_PROMPT = """Erstelle aus den folgenden AMDP-Befunddaten einen medizinischen Fließtext für einen psychiatrischen Befundbericht.
+# ---------------------------------------------------------------------------
+# Schritt 2: AMDP-Fließtext
+# ---------------------------------------------------------------------------
+AMDP_PROMPT = """\
+Erstelle aus den folgenden AMDP-Befunddaten einen medizinischen Fließtext \
+für einen psychiatrischen Befundbericht nach dem CU-Standard.
 
 REGELN:
-- Alle 20 AMDP-Kategorien müssen in exakt dieser Reihenfolge vorkommen:
-  1. Bewusstsein, 2. Orientierung, 3. Aufmerksamkeit, 4. Gedächtnis,
-  5. Formales Denken, 6. Befürchtungen, 7. Wahn, 8. Sinnestäuschungen,
-  9. Ich-Störungen, 10. Zwänge, 11. Phobien, 12. Affektivität,
-  13. Antrieb, 14. Psychomotorik, 15. Circadiane Rhythmik, 16. Schlaf,
-  17. Appetit, 18. Gewicht/BMI, 19. Suizidalität, 20. Eigen-/Fremdgefährdung
+- ALLE 20 Kategorien in EXAKT dieser Reihenfolge:
+  1. Bewusstseinslage, 2. Stimmung, 3. Affekt, 4. Konzentration,
+  5. Merkfähigkeit/Gedächtnis/Auffassung, 6. Interesse,
+  7. Formales Denken, 8. Inhaltliches Denken,
+  9+10. Wahrnehmung UND Ich-Störungen (ZUSAMMEN dokumentieren!),
+  11. Zwänge/Phobien, 12. Antrieb, 13. Psychomotorik,
+  14. Schlaf, 15. Appetit, 16. Gewicht, 17. BMI (SEPARAT als eigene Kategorie!),
+  18. Suizidalität, 19. Eigen-/Fremdgefährdung,
+  20. Psychopharmakologische Vorbehandlung
 - Beginne IMMER mit "Pat."
-- Fließtext, KEINE Aufzählungszeichen, KEIN Markdown
-- Medizinische Fachsprache, knapp und präzise
+- Fließtext mit Punkten als Satzzeichen, KEINE Aufzählungszeichen, KEIN Markdown
+- KEINE Nummerierung
+- Medizinische Fachsprache, knapp und präzise, auf Deutsch
 - Antworte NUR mit dem Fließtext, kein weiterer Text
+
+BEISPIEL-FORMAT:
+"Pat. wach, allseits orientiert. Stimmung gedrückt, im Affekt modulierbar. \
+Konzentration eingeschränkt. Merkfähigkeit, Gedächtnis und Auffassung intakt. \
+Interesse vermindert. Im formalen Denken eingeengt auf Suizidthematik und \
+Zukunftsängste. Inhaltlich kein Wahn. Keine Wahrnehmungs- oder Ich-Störungen. \
+Kein Anhalt für Zwänge oder Phobien. Antrieb vermindert, Psychomotorik ruhig. \
+Schlaf gestört mit Ein- und Durchschlafproblemen. Appetit vermindert. \
+Gewichtsabnahme in den letzten Monaten. BMI 21. Keine akute Suizidalität. \
+Keine akute Eigen- oder Fremdgefährdung. Psychopharmakologische Vorbehandlung \
+mit Escitalopram."
 
 AMDP-BEFUNDDATEN:
 {befund_json}"""
 
-ANAMNESE_PROMPT = """Erstelle aus den folgenden Stichpunkten einen Anamnesetext für einen LaGeSo-Befundbericht.
+# ---------------------------------------------------------------------------
+# Schritt 3: Verlauf + Suchtanamnese
+# ---------------------------------------------------------------------------
+VERLAUF_PROMPT = """\
+Erstelle aus den folgenden Stichpunkten einen Text für den Abschnitt \
+"Verlauf der Erkrankung" und ggf. "Suchterkrankung" eines LaGeSo-Befundberichts.
 
 REGELN:
-- Fließtext, sachlich, medizinisch-fachsprachlich
+- Fließtext, sachlich, medizinisch-fachsprachlich, auf Deutsch
 - KEINE Aufzählungszeichen, KEIN Markdown
 - Zusammenhängender, logisch strukturierter Text
-- Beginne NICHT mit einer Überschrift
+- Bei Suchterkrankung: ALLE 6 Punkte abdecken (Konsummuster, letzter Konsum, \
+Entzugssymptomatik, stationäre Behandlung, Abstinenzstatus, aktuelle Anbindung)
 - Antworte NUR mit dem Fließtext, kein weiterer Text
 
-STICHPUNKTE:
-{stichpunkte}"""
+ANAMNESE/VERLAUF-STICHPUNKTE:
+{anamnese_stichpunkte}
 
-BEURTEILUNG_PROMPT = """Erstelle eine sozialmedizinische Beurteilung für einen LaGeSo-Befundbericht.
+SUCHTERKRANKUNG-DATEN:
+{sucht_daten}
+
+VERLAUFSINFORMATIONEN:
+{verlauf_daten}"""
+
+# ---------------------------------------------------------------------------
+# Schritt 4: Krankheitsbedingte Auswirkungen
+# ---------------------------------------------------------------------------
+AUSWIRKUNGEN_PROMPT = """\
+Erstelle für einen LaGeSo-Befundbericht die drei Abschnitte der \
+"Krankheitsbedingten Auswirkungen" (Alltag, Beruf, Sozial).
 
 REGELN:
-- Sachlich, fachsprachlich, Fließtext
+- Sachlich, fachsprachlich, Fließtext, auf Deutsch
 - KEINE Aufzählungszeichen, KEIN Markdown
-- Auf Basis der Diagnosen und Befunde
-- Beginne NICHT mit einer Überschrift
-- Beziehe dich auf die Auswirkungen der Erkrankung auf die Lebensführung und Teilhabe
-- Antworte NUR mit dem Fließtext, kein weiterer Text
+- Für jeden Bereich (Alltag, Beruf, Sozial) einen separaten Absatz
+- Trenne die drei Bereiche mit genau "---ALLTAG---", "---BERUF---", "---SOZIAL---"
+- Antworte NUR mit den drei Absätzen, kein weiterer Text
 
 DIAGNOSEN:
 {diagnosen}
@@ -103,53 +189,68 @@ DIAGNOSEN:
 BEFUND-ZUSAMMENFASSUNG:
 {befund_zusammenfassung}
 
-ANAMNESE-ZUSAMMENFASSUNG:
-{anamnese_zusammenfassung}"""
+STICHPUNKTE ZU AUSWIRKUNGEN:
+Alltag: {alltag_stichpunkte}
+Beruf: {beruf_stichpunkte}
+Sozial: {sozial_stichpunkte}"""
 
-# AMDP-Kategorien in korrekter Reihenfolge (für Validierung)
+# ---------------------------------------------------------------------------
+# AMDP-Kategorien in CU-Standard Reihenfolge (für Validierung)
+# ---------------------------------------------------------------------------
 AMDP_KATEGORIEN = [
-    "bewusstsein",
-    "orientierung",
-    "aufmerksamkeit",
-    "gedaechtnis",
+    "bewusstseinslage",
+    "stimmung",
+    "affekt",
+    "konzentration",
+    "merkfaehigkeit_gedaechtnis",
+    "interesse",
     "formales_denken",
-    "befuerchtungen",
-    "wahn",
-    "sinnestaueschungen",
-    "ich_stoerungen",
-    "zwang",
-    "phobie",
-    "affektivitaet",
+    "inhaltliches_denken",
+    "wahrnehmung_ich_stoerungen",
+    "zwaenge_phobien",
     "antrieb",
     "psychomotorik",
-    "circadiane_rhythmik",
     "schlaf",
     "appetit",
-    "gewicht_bmi",
+    "gewicht",
+    "bmi",
     "suizidalitaet",
     "eigen_fremdgefaehrdung",
+    "psychopharm_vorbehandlung",
 ]
 
 # Lesbare deutsche Labels für AMDP-Kategorien
 AMDP_LABELS = {
-    "bewusstsein": "Bewusstsein",
-    "orientierung": "Orientierung",
-    "aufmerksamkeit": "Aufmerksamkeit",
-    "gedaechtnis": "Gedächtnis",
+    "bewusstseinslage": "Bewusstseinslage",
+    "stimmung": "Stimmung",
+    "affekt": "Affekt",
+    "konzentration": "Konzentration",
+    "merkfaehigkeit_gedaechtnis": "Merkfähigkeit, Gedächtnis, Auffassung",
+    "interesse": "Interesse",
     "formales_denken": "Formales Denken",
-    "befuerchtungen": "Befürchtungen",
-    "wahn": "Wahn",
-    "sinnestaueschungen": "Sinnestäuschungen",
-    "ich_stoerungen": "Ich-Störungen",
-    "zwang": "Zwänge",
-    "phobie": "Phobien",
-    "affektivitaet": "Affektivität",
+    "inhaltliches_denken": "Inhaltliches Denken",
+    "wahrnehmung_ich_stoerungen": "Wahrnehmung und Ich-Störungen",
+    "zwaenge_phobien": "Zwänge und Phobien",
     "antrieb": "Antrieb",
     "psychomotorik": "Psychomotorik",
-    "circadiane_rhythmik": "Circadiane Rhythmik",
     "schlaf": "Schlaf",
     "appetit": "Appetit",
-    "gewicht_bmi": "Gewicht/BMI",
+    "gewicht": "Gewicht",
+    "bmi": "BMI",
     "suizidalitaet": "Suizidalität",
     "eigen_fremdgefaehrdung": "Eigen-/Fremdgefährdung",
+    "psychopharm_vorbehandlung": "Psychopharmakologische Vorbehandlung",
 }
+
+# Standard-Normalbefund (Template)
+AMDP_NORMALBEFUND = (
+    "Pat. wach und allseits orientiert. Stimmung euthym, im Affekt gut moduliert. "
+    "Konzentration regelrecht. Merkfähigkeit, Gedächtnis und Auffassung intakt. "
+    "Interesse regelrecht. Im formalen Denken kohärent, inhaltlich kein Wahn. "
+    "Weder Wahrnehmungs- noch Ich-Störungen eruierbar. "
+    "Kein Anhalt für Zwänge oder Phobien. "
+    "Antrieb regelrecht, Psychomotorik ruhig. "
+    "Appetit normal, Gewicht konstant. BMI [Zahl]. Schlaf gut. "
+    "Keine akute Suizidalität. Keine akute Eigen- oder Fremdgefährdung. "
+    "Keine psychopharmakologische Vorbehandlung."
+)

--- a/lageso_agent/report_builder.py
+++ b/lageso_agent/report_builder.py
@@ -1,0 +1,120 @@
+"""
+Report Builder: Baut den LaGeSo-Befundbericht aus den extrahierten Daten zusammen.
+Erzeugt die einzelnen Berichtsabschnitte als Text.
+"""
+
+from datetime import date
+
+
+def build_vorstellung(
+    erstvorstellung: str,
+    letzte_vorstellung: str,
+    frequenz: str,
+) -> str:
+    """Baut den Vorstellungs-Abschnitt."""
+    lines = []
+    lines.append(f"erstmalig am: {erstvorstellung or '[BITTE ERGÄNZEN]'}")
+    lines.append(f"letztmalig am: {letzte_vorstellung or '[BITTE ERGÄNZEN]'}")
+    lines.append(f"in welchen Abständen: {frequenz or '[BITTE ERGÄNZEN]'}")
+    return "\n".join(lines)
+
+
+def build_diagnosen(diagnosen: list) -> str:
+    """Baut den Diagnosen-Abschnitt."""
+    if not diagnosen:
+        return "[BITTE ERGÄNZEN]"
+    lines = []
+    for d in diagnosen:
+        icd = d.get("icd", "?")
+        text = d.get("text", "?")
+        lines.append(f"{icd} – {text}")
+    return "\n".join(lines)
+
+
+def build_medikation(medikation: list, datum: str = "") -> str:
+    """Baut den Medikations-Abschnitt."""
+    if not medikation:
+        return "[BITTE ERGÄNZEN]"
+    if not datum:
+        datum = date.today().strftime("%d.%m.%Y")
+    lines = []
+    for med in medikation:
+        name = med.get("name", "?").upper()
+        dosis = med.get("dosis", "")
+        schema = med.get("schema", "")
+        parts = [datum, name]
+        if dosis:
+            parts.append(dosis)
+        if schema:
+            parts.append(schema)
+        lines.append(" ".join(parts))
+    lines.append("")
+    lines.append("(Keine somatische Medikation wird aufgeführt.)")
+    return "\n".join(lines)
+
+
+def build_kopfzeile(arzt_daten: dict) -> str:
+    """Baut die Kopfzeile mit Arzt-Stammdaten."""
+    lines = [
+        arzt_daten.get("name", ""),
+        arzt_daten.get("fachgebiet", ""),
+        arzt_daten.get("adresse", ""),
+        arzt_daten.get("kontakt", ""),
+    ]
+    return "\n".join(line for line in lines if line)
+
+
+def build_full_report(
+    arzt_daten: dict,
+    patient_name: str,
+    geburtsdatum: str,
+    adresse: str,
+    aktenzeichen: str,
+    vorstellung_text: str,
+    diagnosen_text: str,
+    befund_text: str,
+    befund_datum: str,
+    medikation_text: str,
+    anamnese_text: str,
+    beurteilung_text: str,
+) -> str:
+    """Baut den vollständigen Bericht als Gesamttext zusammen.
+
+    Wird primär für die Vorschau verwendet.
+    """
+    heute = date.today().strftime("%d.%m.%Y")
+
+    report = f"""{build_kopfzeile(arzt_daten)}
+
+Berlin, den {heute}
+
+Anlage zur Auskunft über die ärztliche Behandlung (LaGeSo)
+Psychiatrischer/psychotherapeutischer Befundbericht
+
+Patient/in {patient_name or '[Name]'}, geb. am {geburtsdatum or '[Geburtsdatum]'}, wohnhaft in {adresse or '[Adresse]'}
+Aktenzeichen: {aktenzeichen or '[Aktenzeichen]'}
+
+1. VORSTELLUNG
+{vorstellung_text}
+
+2. DIAGNOSEN (ICD-10)
+{diagnosen_text}
+
+3. PSYCHOPATHOLOGISCHER BEFUND
+(AMDP-System – letzter Befund vom {befund_datum or heute})
+{befund_text}
+
+4. AKTUELLE MEDIKATION (nur psychopharmakologisch)
+{medikation_text}
+
+5. ANAMNESE UND BEHANDLUNGSVERLAUF
+{anamnese_text}
+
+6. SOZIALMEDIZINISCHE BEURTEILUNG
+{beurteilung_text}
+
+
+___________________________
+{arzt_daten.get('name', '')}"""
+
+    return report

--- a/lageso_agent/report_builder.py
+++ b/lageso_agent/report_builder.py
@@ -1,6 +1,7 @@
 """
 Report Builder: Baut den LaGeSo-Befundbericht aus den extrahierten Daten zusammen.
 Erzeugt die einzelnen Berichtsabschnitte als Text.
+Vollständige 12-Abschnitt-Struktur nach CU-Standard.
 """
 
 from datetime import date
@@ -12,37 +13,44 @@ def build_vorstellung(
     frequenz: str,
 ) -> str:
     """Baut den Vorstellungs-Abschnitt."""
-    lines = []
-    lines.append(f"erstmalig am: {erstvorstellung or '[BITTE ERGÄNZEN]'}")
-    lines.append(f"letztmalig am: {letzte_vorstellung or '[BITTE ERGÄNZEN]'}")
-    lines.append(f"in welchen Abständen: {frequenz or '[BITTE ERGÄNZEN]'}")
+    lines = [
+        f"a) erstmalig am: {erstvorstellung or '[FEHLT]'}",
+        f"b) letztmalig am: {letzte_vorstellung or '[FEHLT]'}",
+        f"c) in welchen Abständen: {frequenz or '[FEHLT]'}",
+    ]
     return "\n".join(lines)
 
 
 def build_diagnosen(diagnosen: list) -> str:
-    """Baut den Diagnosen-Abschnitt."""
+    """Baut den Diagnosen-Abschnitt mit ICD-10 Codes."""
     if not diagnosen:
-        return "[BITTE ERGÄNZEN]"
+        return "[FEHLT]"
     lines = []
     for d in diagnosen:
         icd = d.get("icd", "?")
         text = d.get("text", "?")
-        lines.append(f"{icd} – {text}")
+        lines.append(f"{icd} ({text})")
     return "\n".join(lines)
 
 
-def build_medikation(medikation: list, datum: str = "") -> str:
-    """Baut den Medikations-Abschnitt."""
+def build_medikation(medikation: list) -> str:
+    """Baut den Medikations-Abschnitt.
+
+    Format: DATUM MEDIKAMENTENNAME DOSIERUNG SCHEMA
+    NUR Psychopharmaka, KEIN Tabellenformat.
+    """
     if not medikation:
-        return "[BITTE ERGÄNZEN]"
-    if not datum:
-        datum = date.today().strftime("%d.%m.%Y")
+        return "[FEHLT]"
     lines = []
     for med in medikation:
+        datum = med.get("datum", "")
         name = med.get("name", "?").upper()
         dosis = med.get("dosis", "")
         schema = med.get("schema", "")
-        parts = [datum, name]
+        parts = []
+        if datum:
+            parts.append(datum)
+        parts.append(name)
         if dosis:
             parts.append(dosis)
         if schema:
@@ -51,6 +59,101 @@ def build_medikation(medikation: list, datum: str = "") -> str:
     lines.append("")
     lines.append("(Keine somatische Medikation wird aufgeführt.)")
     return "\n".join(lines)
+
+
+def build_verlauf(verlauf: dict, verlauf_text: str) -> str:
+    """Baut den Verlauf-Abschnitt mit Checkbox-Angaben und Fließtext."""
+    form = verlauf.get("form", "nicht erhoben")
+    tendenz = verlauf.get("tendenz", "")
+    erfolg = verlauf.get("behandlungserfolg", "nicht erhoben")
+
+    lines = []
+    lines.append("Verlaufsform:")
+    if form == "phasenhaft":
+        phasen = verlauf.get("phasen_anzahl", "?")
+        lines.append(f"  phasenhaft - Anzahl der Phasen in den letzten 2 Jahren: {phasen}")
+    else:
+        lines.append(f"  dauerhaft mit Tendenz: {tendenz}")
+
+    lines.append("")
+    lines.append("Behandlungserfolg:")
+    lines.append(f"  Durch die bisher durchgeführte Behandlung: {erfolg}")
+
+    if verlauf_text and verlauf_text != "[BITTE ERGÄNZEN]":
+        lines.append("")
+        lines.append(verlauf_text)
+
+    return "\n".join(lines)
+
+
+def build_sucht(sucht: dict, sucht_text: str) -> str:
+    """Baut den Sucht-Abschnitt."""
+    if not sucht.get("vorhanden"):
+        return "Keine Suchterkrankung bekannt."
+
+    abstinenz = sucht.get("abstinenz_seit", "")
+    if abstinenz:
+        header = f"Abstinenz seit: {abstinenz}"
+    else:
+        header = "Fortgesetzter Konsum"
+
+    lines = [header]
+    if sucht_text and sucht_text != "Keine Suchterkrankung bekannt.":
+        lines.append("")
+        lines.append(sucht_text)
+
+    return "\n".join(lines)
+
+
+def build_psychosoziale_hilfen(hilfen: dict) -> str:
+    """Baut den Abschnitt Psychosoziale Hilfen aus den Checkbox-Daten."""
+    lines = []
+
+    # Gesetzliche Betreuung
+    if hilfen.get("betreuung"):
+        bereiche = hilfen.get("betreuung_bereiche", "[FEHLT]")
+        lines.append(f"Gesetzliche Betreuung: ja - für: {bereiche}")
+    else:
+        lines.append("Gesetzliche Betreuung: nein")
+
+    # Einzelhilfe
+    val = "ja" if hilfen.get("einzelhilfe") else "nein"
+    lines.append(f"Einzelhilfe: {val}")
+
+    # Betreutes Wohnen
+    val = "ja" if hilfen.get("betreutes_wohnen") else "nein"
+    lines.append(f"Betreutes Wohnen: {val}")
+
+    # Heimunterbringung
+    val = "ja" if hilfen.get("heimunterbringung") else "nein"
+    lines.append(f"Heimunterbringung: {val}")
+
+    # Pflegegrad
+    pflegegrad = hilfen.get("pflegegrad", "keiner")
+    lines.append(f"Pflegegrad: {pflegegrad}")
+
+    # AU
+    if hilfen.get("au_psychisch"):
+        seit = hilfen.get("au_seit", "[FEHLT]")
+        lines.append(f"AU wegen psychischer Erkrankung: ja - seit: {seit}")
+    else:
+        lines.append("AU wegen psychischer Erkrankung: nein")
+
+    # Berentung
+    if hilfen.get("berentung"):
+        seit = hilfen.get("berentung_seit", "[FEHLT]")
+        lines.append(f"Berentung wegen psychischer Erkrankung: ja - seit: {seit}")
+    else:
+        lines.append("Berentung wegen psychischer Erkrankung: nein")
+
+    return "\n".join(lines)
+
+
+def build_gehfaehigkeit(eingeschraenkt: bool, beschreibung: str) -> str:
+    """Baut den Gehfähigkeits-Abschnitt."""
+    if eingeschraenkt:
+        return f"Ja, inwiefern: {beschreibung or '[FEHLT]'}"
+    return "Nein"
 
 
 def build_kopfzeile(arzt_daten: dict) -> str:
@@ -68,21 +171,34 @@ def build_full_report(
     arzt_daten: dict,
     patient_name: str,
     geburtsdatum: str,
-    adresse: str,
+    plz_ort: str,
+    strasse: str,
     aktenzeichen: str,
     vorstellung_text: str,
     diagnosen_text: str,
     befund_text: str,
     befund_datum: str,
     medikation_text: str,
-    anamnese_text: str,
-    beurteilung_text: str,
+    verlauf_text: str,
+    sucht_text: str,
+    behandlungen_text: str,
+    psychosoziale_hilfen_text: str,
+    auswirkungen_alltag: str,
+    auswirkungen_beruf: str,
+    auswirkungen_sozial: str,
+    gehfaehigkeit_text: str,
+    akteneinsicht: bool,
+    akteneinsicht_begruendung: str,
 ) -> str:
-    """Baut den vollständigen Bericht als Gesamttext zusammen.
-
-    Wird primär für die Vorschau verwendet.
-    """
+    """Baut den vollständigen 12-Abschnitt-Bericht als Gesamttext."""
     heute = date.today().strftime("%d.%m.%Y")
+
+    # Adresse formatieren: PLZ Ort, Straße
+    adresse_full = f"{plz_ort}, {strasse}" if plz_ort and strasse else (plz_ort or strasse or "[Adresse]")
+
+    akteneinsicht_text = "Ja"
+    if not akteneinsicht:
+        akteneinsicht_text = f"Nein - Begründung: {akteneinsicht_begruendung or '[FEHLT]'}"
 
     report = f"""{build_kopfzeile(arzt_daten)}
 
@@ -91,27 +207,57 @@ Berlin, den {heute}
 Anlage zur Auskunft über die ärztliche Behandlung (LaGeSo)
 Psychiatrischer/psychotherapeutischer Befundbericht
 
-Patient/in {patient_name or '[Name]'}, geb. am {geburtsdatum or '[Geburtsdatum]'}, wohnhaft in {adresse or '[Adresse]'}
+Patient/in {patient_name or '[Name]'}, geb. am {geburtsdatum or '[Geburtsdatum]'}, wohnhaft in {adresse_full}
 Aktenzeichen: {aktenzeichen or '[Aktenzeichen]'}
 
 1. VORSTELLUNG
+Die Vorstellung erfolgte:
 {vorstellung_text}
 
 2. DIAGNOSEN (ICD-10)
 {diagnosen_text}
 
 3. PSYCHOPATHOLOGISCHER BEFUND
-(AMDP-System – letzter Befund vom {befund_datum or heute})
+(AMDP-System - letzter Befund vom {befund_datum or heute})
 {befund_text}
 
 4. AKTUELLE MEDIKATION (nur psychopharmakologisch)
 {medikation_text}
 
-5. ANAMNESE UND BEHANDLUNGSVERLAUF
-{anamnese_text}
+5. VERLAUF DER ERKRANKUNG
+{verlauf_text}
 
-6. SOZIALMEDIZINISCHE BEURTEILUNG
-{beurteilung_text}
+6. BEI SUCHTERKRANKUNG
+{sucht_text}
+
+7. SONSTIGE BEHANDLUNGEN (wo?, wann?)
+{behandlungen_text}
+
+8. PSYCHOSOZIALE HILFEN
+{psychosoziale_hilfen_text}
+
+9. KRANKHEITSBEDINGTE AUSWIRKUNGEN
+
+Alltag:
+{auswirkungen_alltag}
+
+Beruf:
+{auswirkungen_beruf}
+
+Sozial:
+{auswirkungen_sozial}
+
+10. EINSCHRÄNKUNGEN DER GEHFÄHIGKEIT
+{gehfaehigkeit_text}
+
+11. AKTENEINSICHT
+Im Falle einer Akteneinsicht kann dieser Befundbericht dem/der Antragsteller/in zur Einsicht gegeben werden?
+{akteneinsicht_text}
+
+12. ABSCHLUSS
+Den Befundbericht bitte ich gemäß beiliegender Liquidation zu entschädigen.
+
+Mit freundlichen Grüßen
 
 
 ___________________________

--- a/lageso_agent/requirements.txt
+++ b/lageso_agent/requirements.txt
@@ -1,0 +1,4 @@
+streamlit>=1.30.0
+python-docx>=1.1.0
+requests>=2.31.0
+pydantic>=2.5.0

--- a/lageso_agent/start.sh
+++ b/lageso_agent/start.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+#
+# Startskript für den LaGeSo Befundbericht Generator.
+# Prüft Voraussetzungen und startet Streamlit.
+#
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$SCRIPT_DIR"
+
+echo "============================================"
+echo "  LaGeSo Befundbericht Generator"
+echo "============================================"
+echo ""
+
+# --- Python prüfen ---
+if ! command -v python3 &> /dev/null; then
+    echo "FEHLER: Python 3 ist nicht installiert."
+    echo "Bitte installieren Sie Python 3.9 oder höher."
+    exit 1
+fi
+
+PYTHON_VERSION=$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")
+echo "Python: $PYTHON_VERSION"
+
+# --- pip-Abhängigkeiten prüfen ---
+echo "Prüfe Abhängigkeiten..."
+if ! python3 -c "import streamlit" 2>/dev/null; then
+    echo "Installiere Abhängigkeiten..."
+    pip3 install -r requirements.txt
+fi
+
+# --- Ollama prüfen ---
+echo ""
+if command -v ollama &> /dev/null; then
+    echo "Ollama: installiert"
+    if curl -s http://localhost:11434/api/tags > /dev/null 2>&1; then
+        echo "Ollama-Server: läuft"
+        MODELS=$(curl -s http://localhost:11434/api/tags | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+models = [m['name'] for m in data.get('models', [])]
+print(', '.join(models) if models else 'keine Modelle geladen')
+" 2>/dev/null || echo "Fehler beim Abrufen")
+        echo "Verfügbare Modelle: $MODELS"
+    else
+        echo "WARNUNG: Ollama ist installiert, aber der Server läuft nicht."
+        echo "Starten Sie Ollama mit: ollama serve"
+        echo ""
+        echo "Die App wird trotzdem gestartet. Sie können Ollama später starten"
+        echo "und die Verbindung in der App testen."
+    fi
+else
+    echo "WARNUNG: Ollama ist nicht installiert."
+    echo "Installieren Sie Ollama von: https://ollama.ai"
+    echo ""
+    echo "Die App wird trotzdem gestartet."
+fi
+
+# --- Streamlit starten ---
+echo ""
+echo "Starte Streamlit..."
+echo "Die App öffnet sich im Browser unter: http://localhost:8501"
+echo ""
+
+python3 -m streamlit run app.py \
+    --server.headless true \
+    --server.port 8501 \
+    --browser.gatherUsageStats false


### PR DESCRIPTION
Implements a local web application for generating structured psychiatric
LaGeSo reports (CU-Standard) from unstructured clinical text using a
multi-step LLM extraction pipeline via Ollama.

- app.py: 2-panel Streamlit UI with input/output, editable sections
- llm_client.py: Ollama HTTP client with connection test, JSON extraction
- extractor.py: 4-step pipeline (extraction, AMDP, anamnesis, assessment)
- report_builder.py: Assembles report sections into CU-Standard format
- docx_export.py: Word export with Arial 11pt, proper formatting
- prompts.py: All German medical prompt templates and AMDP categories
- start.sh: Startup script with dependency and Ollama checks

https://claude.ai/code/session_01CwB6s1R2pgacY7BRWPQznC